### PR TITLE
refactor: implement ScreenUtil scaling for profile section

### DIFF
--- a/lib/features/onboarding/presentation/screens/backup_choice_screen.dart
+++ b/lib/features/onboarding/presentation/screens/backup_choice_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:sabi_wallet/core/constants/colors.dart';
 import 'package:sabi_wallet/features/onboarding/presentation/screens/wallet_creation_animation_screen.dart';
 import '../providers/onboarding_provider.dart';
@@ -16,7 +17,7 @@ class BackupChoiceScreen extends ConsumerWidget {
       backgroundColor: AppColors.background,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 31, vertical: 29),
+          padding: EdgeInsets.symmetric(horizontal: 31.w, vertical: 29.h),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -27,22 +28,22 @@ class BackupChoiceScreen extends ConsumerWidget {
                     child: Icon(
                       Icons.arrow_back,
                       color: AppColors.textPrimary,
-                      size: 24,
+                      size: 24.w,
                     ),
                   ),
-                  const SizedBox(width: 10),
-                  const Text(
+                  SizedBox(width: 10.w),
+                  Text(
                     'Choose your backup method',
                     style: TextStyle(
                       color: AppColors.textPrimary,
-                      fontSize: 18,
+                      fontSize: 18.sp,
                       fontWeight: FontWeight.w500,
                       height: 1.78,
                     ),
                   ),
                 ],
               ),
-              const SizedBox(height: 28),
+              SizedBox(height: 28.h),
               Expanded(
                 child: SingleChildScrollView(
                   child: Column(
@@ -51,9 +52,12 @@ class BackupChoiceScreen extends ConsumerWidget {
                         recommended: true,
                         icon: Icons.people_outline,
                         iconColor: AppColors.primary,
-                        iconBackgroundColor: AppColors.primary.withValues(alpha: 0.2),
+                        iconBackgroundColor: AppColors.primary.withValues(
+                          alpha: 0.2,
+                        ),
                         title: 'Pick 3 trusted guys',
-                        description: 'No seed phrase. Your guys wey dey use \nBitcoin/Nostr go help you recover.',
+                        description:
+                            'No seed phrase. Your guys wey dey use \nBitcoin/Nostr go help you recover.',
                         featureText: 'Most secure for Nigerian users',
                         featureIcon: Icons.check_circle_outline,
                         featureIconColor: AppColors.accentGreen,
@@ -62,29 +66,35 @@ class BackupChoiceScreen extends ConsumerWidget {
                         buttonTextColor: AppColors.textPrimary,
                         borderColor: AppColors.primary,
                         onTap: () async {
-                          ref.read(onboardingNotifierProvider.notifier).setBackupMethod(BackupMethod.socialRecovery);
-                          
-                            // Create wallet with backup_type='social' (handles errors silently)
-                            await WalletCreationHelper.createWalletWithBackupType(
-                              ref: ref,
-                              backupType: 'social',
-                            );
-                          
+                          ref
+                              .read(onboardingNotifierProvider.notifier)
+                              .setBackupMethod(BackupMethod.socialRecovery);
+
+                          await WalletCreationHelper.createWalletWithBackupType(
+                            ref: ref,
+                            backupType: 'social',
+                          );
+
                           if (context.mounted) {
                             Navigator.push(
                               context,
-                              MaterialPageRoute(builder: (_) => const SocialRecoveryScreen()),
+                              MaterialPageRoute(
+                                builder: (_) => const SocialRecoveryScreen(),
+                              ),
                             );
                           }
                         },
                       ),
-                      const SizedBox(height: 30),
+                      SizedBox(height: 30.h),
                       _BackupOptionCard(
                         icon: Icons.vpn_key_outlined,
                         iconColor: AppColors.textTertiary,
-                        iconBackgroundColor: AppColors.borderColor.withValues(alpha: 0.5),
+                        iconBackgroundColor: AppColors.borderColor.withValues(
+                          alpha: 0.5,
+                        ),
                         title: 'Classic 12-word backup',
-                        description: 'Old-school seed phrase. You go write am \ndown yourself.',
+                        description:
+                            'Old-school seed phrase. You go write am \ndown yourself.',
                         featureText: 'You must keep the paper safe',
                         featureIcon: Icons.warning_amber_outlined,
                         featureIconColor: AppColors.accentYellow,
@@ -92,29 +102,35 @@ class BackupChoiceScreen extends ConsumerWidget {
                         buttonColor: AppColors.surface,
                         buttonTextColor: AppColors.textPrimary,
                         onTap: () async {
-                          ref.read(onboardingNotifierProvider.notifier).setBackupMethod(BackupMethod.seedPhrase);
-                          
-                            // Create wallet with backup_type='seed' (handles errors silently)
-                            await WalletCreationHelper.createWalletWithBackupType(
-                              ref: ref,
-                              backupType: 'seed',
-                            );
-                          
+                          ref
+                              .read(onboardingNotifierProvider.notifier)
+                              .setBackupMethod(BackupMethod.seedPhrase);
+
+                          await WalletCreationHelper.createWalletWithBackupType(
+                            ref: ref,
+                            backupType: 'seed',
+                          );
+
                           if (context.mounted) {
                             Navigator.push(
                               context,
-                              MaterialPageRoute(builder: (_) => const SeedPhraseScreen()),
+                              MaterialPageRoute(
+                                builder: (_) => const SeedPhraseScreen(),
+                              ),
                             );
                           }
                         },
                       ),
-                      const SizedBox(height: 30),
+                      SizedBox(height: 30.h),
                       _BackupOptionCard(
                         icon: Icons.warning_amber_outlined,
                         iconColor: AppColors.accentRed,
-                        iconBackgroundColor: AppColors.accentRed.withValues(alpha: 0.2),
+                        iconBackgroundColor: AppColors.accentRed.withValues(
+                          alpha: 0.2,
+                        ),
                         title: 'Skip for now',
-                        description: 'You fit set am later for Settings. But if phone \nloss, money go loss forever o.',
+                        description:
+                            'You fit set am later for Settings. But if phone \nloss, money go loss forever o.',
                         featureText: 'Very dangerous - not recommended',
                         featureIcon: Icons.warning_amber_outlined,
                         featureIconColor: AppColors.accentRed,
@@ -124,18 +140,22 @@ class BackupChoiceScreen extends ConsumerWidget {
                         buttonTextColor: AppColors.primary,
                         borderColor: AppColors.primary,
                         onTap: () async {
-                          ref.read(onboardingNotifierProvider.notifier).setBackupMethod(BackupMethod.skip);
+                          ref
+                              .read(onboardingNotifierProvider.notifier)
+                              .setBackupMethod(BackupMethod.skip);
 
-                          // Create wallet with backup_type=none
                           await WalletCreationHelper.createWalletWithBackupType(
                             ref: ref,
                             backupType: 'none',
                           );
 
-                          // Show wallet creation animation, then navigate to home
                           if (context.mounted) {
                             Navigator.of(context).pushAndRemoveUntil(
-                              MaterialPageRoute(builder: (_) => const WalletCreationAnimationScreen()),
+                              MaterialPageRoute(
+                                builder:
+                                    (_) =>
+                                        const WalletCreationAnimationScreen(),
+                              ),
                               (route) => false,
                             );
                           }
@@ -191,18 +211,16 @@ class _BackupOptionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(25),
+      padding: EdgeInsets.all(25.w),
       decoration: BoxDecoration(
         color: AppColors.surface,
-        borderRadius: BorderRadius.circular(20),
-        border: borderColor != null
-            ? Border.all(color: borderColor!)
-            : null,
+        borderRadius: BorderRadius.circular(20.r),
+        border: borderColor != null ? Border.all(color: borderColor!) : null,
         boxShadow: [
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.15),
-            blurRadius: 8,
-            offset: const Offset(0, 4),
+            blurRadius: 8.r,
+            offset: Offset(0, 4.h),
           ),
         ],
       ),
@@ -214,30 +232,29 @@ class _BackupOptionCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Container(
-                width: 48,
-                height: 48,
+                width: 48.w,
+                height: 48.w,
                 decoration: BoxDecoration(
                   color: iconBackgroundColor,
                   shape: BoxShape.circle,
                 ),
-                child: Icon(
-                  icon,
-                  color: iconColor,
-                  size: 24,
-                ),
+                child: Icon(icon, color: iconColor, size: 24.sp),
               ),
               if (recommended)
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 12.w,
+                    vertical: 4.h,
+                  ),
                   decoration: BoxDecoration(
                     color: AppColors.primary.withValues(alpha: 0.2),
-                    borderRadius: BorderRadius.circular(9999),
+                    borderRadius: BorderRadius.circular(9999.r),
                   ),
-                  child: const Text(
+                  child: Text(
                     'RECOMMENDED',
                     style: TextStyle(
                       color: AppColors.primary,
-                      fontSize: 10,
+                      fontSize: 10.sp,
                       fontWeight: FontWeight.w700,
                       height: 1.6,
                     ),
@@ -245,67 +262,67 @@ class _BackupOptionCard extends StatelessWidget {
                 ),
             ],
           ),
-          const SizedBox(height: 14),
+          SizedBox(height: 14.h),
           Text(
             title,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textPrimary,
-              fontSize: 17,
+              fontSize: 17.sp,
               fontWeight: FontWeight.w700,
               height: 1.65,
             ),
           ),
-          const SizedBox(height: 14),
+          SizedBox(height: 14.h),
           Text(
             description,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textTertiary,
-              fontSize: 12,
+              fontSize: 12.sp,
               fontWeight: FontWeight.w400,
               height: 1.83,
             ),
           ),
-          const SizedBox(height: 14),
+          SizedBox(height: 14.h),
           Row(
             children: [
-              Icon(
-                featureIcon,
-                color: featureIconColor,
-                size: 16,
-              ),
-              const SizedBox(width: 8),
+              Icon(featureIcon, color: featureIconColor, size: 16.sp),
+              SizedBox(width: 8.w),
               Text(
                 featureText,
                 style: TextStyle(
                   color: featureTextColor ?? AppColors.textTertiary,
-                  fontSize: 10,
-                  fontWeight: featureTextColor != null ? FontWeight.w500 : FontWeight.w400,
+                  fontSize: 10.sp,
+                  fontWeight:
+                      featureTextColor != null
+                          ? FontWeight.w500
+                          : FontWeight.w400,
                   height: 1.6,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 14),
+          SizedBox(height: 14.h),
           SizedBox(
             width: double.infinity,
-            height: 50,
+            height: 50.h,
             child: ElevatedButton(
               onPressed: onTap,
               style: ElevatedButton.styleFrom(
                 backgroundColor: buttonColor,
                 foregroundColor: buttonTextColor,
                 elevation: 0,
-                side: buttonColor == Colors.transparent && borderColor != null
-                    ? BorderSide(color: borderColor!)
-                    : null,
+                side:
+                    buttonColor == Colors.transparent && borderColor != null
+                        ? BorderSide(color: borderColor!)
+                        : null,
                 shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
+                  borderRadius: BorderRadius.circular(16.r),
                 ),
               ),
               child: Text(
                 buttonText,
                 style: TextStyle(
-                  fontSize: 14,
+                  fontSize: 14.sp,
                   fontWeight: FontWeight.w500,
                   height: 1.71,
                   color: buttonTextColor,

--- a/lib/features/onboarding/presentation/screens/seed_phrase_screen.dart
+++ b/lib/features/onboarding/presentation/screens/seed_phrase_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:sabi_wallet/core/constants/colors.dart';
 import 'package:sabi_wallet/features/onboarding/presentation/screens/wallet_creation_animation_screen.dart';
 import 'package:sabi_wallet/core/services/secure_storage_service.dart';
@@ -9,11 +10,8 @@ import 'package:bip39/bip39.dart' as bip39;
 
 class SeedPhraseScreen extends ConsumerStatefulWidget {
   final bool isRestoring;
-  
-  const SeedPhraseScreen({
-    super.key,
-    this.isRestoring = false,
-  });
+
+  const SeedPhraseScreen({super.key, this.isRestoring = false});
 
   @override
   ConsumerState<SeedPhraseScreen> createState() => _SeedPhraseScreenState();
@@ -35,23 +33,25 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
       // Try to get existing mnemonic from secure storage
       final storage = ref.read(secureStorageServiceProvider);
       String? mnemonic = await storage.getMnemonic();
-      
+
       // If no mnemonic exists, generate a new one (shouldn't happen in normal flow)
       if (mnemonic == null || mnemonic.isEmpty) {
         mnemonic = bip39.generateMnemonic(strength: 256); // 256 bits = 24 words
         await storage.saveMnemonic(mnemonic);
       }
-      
+
       setState(() {
         _seedWords = mnemonic!.split(' ');
         _isLoading = false;
       });
     } catch (e) {
       // Fallback: generate new mnemonic
-      final mnemonic = bip39.generateMnemonic(strength: 256); // 256 bits = 24 words
+      final mnemonic = bip39.generateMnemonic(
+        strength: 256,
+      ); // 256 bits = 24 words
       final storage = ref.read(secureStorageServiceProvider);
       await storage.saveMnemonic(mnemonic);
-      
+
       setState(() {
         _seedWords = mnemonic.split(' ');
         _isLoading = false;
@@ -72,8 +72,11 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
     Clipboard.setData(ClipboardData(text: seedPhrase));
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: const Text('Seed phrase copied to clipboard'),
-        backgroundColor: AppColors.primary,
+        content: Text(
+          'Seed phrase copied to clipboard',
+          style: TextStyle(color: AppColors.surface),
+        ),
+        backgroundColor: AppColors.accentGreen,
         duration: const Duration(seconds: 2),
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
@@ -100,12 +103,12 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
         ),
       );
     }
-    
+
     return Scaffold(
       backgroundColor: AppColors.background,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(31, 29, 31, 30),
+          padding: EdgeInsets.fromLTRB(31.w, 29.h, 31.w, 30.h),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -114,23 +117,21 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
                   GestureDetector(
                     onTap: () => Navigator.pop(context),
                     child: SizedBox(
-                      width: 24,
-                      height: 24,
-                      child: CustomPaint(
-                        painter: BackArrowPainter(),
-                      ),
+                      width: 24.w,
+                      height: 24.h,
+                      child: CustomPaint(painter: BackArrowPainter()),
                     ),
                   ),
-                  const SizedBox(width: 10),
+                  SizedBox(width: 10.w),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Text(
+                        Text(
                           'Your 24-Word Backup',
                           style: TextStyle(
                             color: AppColors.textPrimary,
-                            fontSize: 18,
+                            fontSize: 18.sp,
                             fontWeight: FontWeight.w500,
                             height: 32 / 18,
                           ),
@@ -138,8 +139,8 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
                         Text(
                           'Write down all 24 words in order',
                           style: TextStyle(
-                            color: Color(0xFF9CA3AF),
-                            fontSize: 12,
+                            color: AppColors.textTertiary,
+                            fontSize: 12.sp,
                             fontWeight: FontWeight.w400,
                             height: 20 / 12,
                           ),
@@ -149,21 +150,20 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
                   ),
                 ],
               ),
-              const SizedBox(height: 28),
+              SizedBox(height: 28.h),
               Expanded(
                 child: SingleChildScrollView(
                   child: Column(
+                    spacing: 25.h,
                     children: [
                       _buildWarningCard(),
-                      const SizedBox(height: 30),
                       _buildSeedPhraseCard(),
-                      const SizedBox(height: 30),
                       _buildSecurityTipsCard(),
                     ],
                   ),
                 ),
               ),
-              const SizedBox(height: 24),
+              SizedBox(height: 24.h),
               _buildBottomButton(),
             ],
           ),
@@ -174,10 +174,10 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
 
   Widget _buildWarningCard() {
     return Container(
-      padding: const EdgeInsets.all(21),
+      padding: EdgeInsets.all(21.h),
       decoration: BoxDecoration(
         color: Color(0xFF111128).withValues(alpha: 0.05),
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: BorderRadius.circular(20.r),
         border: Border.all(color: AppColors.accentRed, width: 1),
         boxShadow: [
           BoxShadow(
@@ -191,32 +191,30 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SizedBox(
-            width: 24,
-            height: 24,
-            child: CustomPaint(
-              painter: WarningIconPainter(),
-            ),
+            width: 24.w,
+            height: 24.h,
+            child: CustomPaint(painter: WarningIconPainter()),
           ),
-          const SizedBox(width: 12),
+          SizedBox(width: 12.w),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text(
+                Text(
                   'Never share your seed phrase',
                   style: TextStyle(
                     color: AppColors.accentRed,
-                    fontSize: 14,
+                    fontSize: 14.sp,
                     fontWeight: FontWeight.w700,
                     height: 24 / 14,
                   ),
                 ),
-                const SizedBox(height: 7),
+                SizedBox(height: 7.h),
                 Text(
                   'Anyone with these 12 words can steal your Bitcoin. Write am down for paper and keep am safe.',
                   style: TextStyle(
                     color: Color(0xFFD1D5DB),
-                    fontSize: 12,
+                    fontSize: 12.sp,
                     fontWeight: FontWeight.w400,
                     height: 22 / 12,
                   ),
@@ -231,10 +229,10 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
 
   Widget _buildSeedPhraseCard() {
     return Container(
-      padding: const EdgeInsets.all(24),
+      padding: EdgeInsets.all(24.h),
       decoration: BoxDecoration(
         color: AppColors.surface,
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: BorderRadius.circular(20.r),
         boxShadow: [
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.15),
@@ -251,22 +249,17 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
               if (!_isRevealed)
                 Positioned.fill(
                   child: ClipRRect(
-                    borderRadius: BorderRadius.circular(8),
+                    borderRadius: BorderRadius.circular(8.r),
                     child: BackdropFilter(
                       filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
-                      child: Container(
-                        color: Colors.transparent,
-                      ),
+                      child: Container(color: Colors.transparent),
                     ),
                   ),
                 ),
             ],
           ),
-          const SizedBox(height: 16),
-          if (!_isRevealed)
-            _buildRevealButton()
-          else
-            _buildActionButtons(),
+          SizedBox(height: 16.h),
+          if (!_isRevealed) _buildRevealButton() else _buildActionButtons(),
         ],
       ),
     );
@@ -285,10 +278,10 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
       itemCount: _seedWords.length,
       itemBuilder: (context, index) {
         return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 12.h),
           decoration: BoxDecoration(
             color: AppColors.background,
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(8.r),
           ),
           child: Row(
             children: [
@@ -296,17 +289,17 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
                 '${index + 1}.',
                 style: TextStyle(
                   color: Color(0xFF6B7280),
-                  fontSize: 12,
+                  fontSize: 12.sp,
                   fontWeight: FontWeight.w400,
                   height: 20 / 12,
                 ),
               ),
-              const SizedBox(width: 12),
+              SizedBox(width: 12.w),
               Text(
                 _seedWords[index],
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textPrimary,
-                  fontSize: 14,
+                  fontSize: 14.sp,
                   fontWeight: FontWeight.w500,
                   height: 24 / 14,
                 ),
@@ -321,7 +314,7 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
   Widget _buildRevealButton() {
     return SizedBox(
       width: double.infinity,
-      height: 50,
+      height: 52.h,
       child: ElevatedButton(
         onPressed: _onRevealPressed,
         style: ElevatedButton.styleFrom(
@@ -329,24 +322,23 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
           foregroundColor: AppColors.textPrimary,
           elevation: 0,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: BorderRadius.circular(16.r),
           ),
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             SizedBox(
-              width: 20,
-              height: 20,
-              child: CustomPaint(
-                painter: EyeIconPainter(),
-              ),
+              width: 20.w,
+              height: 20.h,
+              child: CustomPaint(painter: EyeIconPainter()),
             ),
-            const SizedBox(width: 8),
-            const Text(
+            SizedBox(width: 8.w),
+            Text(
               'Reveal Seed Phrase',
               style: TextStyle(
-                fontSize: 14,
+                fontSize: 14.sp,
+                color: AppColors.surface,
                 fontWeight: FontWeight.w500,
                 height: 24 / 14,
               ),
@@ -362,7 +354,7 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
       children: [
         SizedBox(
           width: double.infinity,
-          height: 50,
+          height: 52.h,
           child: OutlinedButton(
             onPressed: _onHidePressed,
             style: OutlinedButton.styleFrom(
@@ -371,24 +363,22 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
               elevation: 0,
               backgroundColor: Colors.transparent,
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
+                borderRadius: BorderRadius.circular(16.r),
               ),
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CustomPaint(
-                    painter: EyeOffIconPainter(),
-                  ),
+                  width: 20.w,
+                  height: 20.h,
+                  child: CustomPaint(painter: EyeOffIconPainter()),
                 ),
-                const SizedBox(width: 8),
-                const Text(
+                SizedBox(width: 8.w),
+                Text(
                   'Hide Seed Phrase',
                   style: TextStyle(
-                    fontSize: 14,
+                    fontSize: 14.sp,
                     fontWeight: FontWeight.w500,
                     height: 24 / 14,
                   ),
@@ -397,10 +387,10 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
             ),
           ),
         ),
-        const SizedBox(height: 12),
+        SizedBox(height: 12.h),
         SizedBox(
           width: double.infinity,
-          height: 50,
+          height: 52.h,
           child: ElevatedButton(
             onPressed: _onCopyToClipboard,
             style: ElevatedButton.styleFrom(
@@ -408,24 +398,23 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
               foregroundColor: AppColors.textPrimary,
               elevation: 0,
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
+                borderRadius: BorderRadius.circular(16.r),
               ),
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CustomPaint(
-                    painter: CopyIconPainter(),
-                  ),
+                  width: 20.w,
+                  height: 20.h,
+                  child: CustomPaint(painter: CopyIconPainter()),
                 ),
-                const SizedBox(width: 8),
-                const Text(
+                SizedBox(width: 8.w),
+                Text(
                   'Copy to Clipboard',
                   style: TextStyle(
-                    fontSize: 14,
+                    fontSize: 14.sp,
+                    color: AppColors.textPrimary.withValues(alpha: 0.75),
                     fontWeight: FontWeight.w500,
                     height: 24 / 14,
                   ),
@@ -440,10 +429,10 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
 
   Widget _buildSecurityTipsCard() {
     return Container(
-      padding: const EdgeInsets.all(20),
+      padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 20.h),
       decoration: BoxDecoration(
         color: AppColors.surface,
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: BorderRadius.circular(20.r),
         boxShadow: [
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.15),
@@ -453,23 +442,22 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
         ],
       ),
       child: Column(
+        spacing: 11.h,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             'Security Tips',
             style: TextStyle(
               color: AppColors.textPrimary,
-              fontSize: 14,
+              fontSize: 14.sp,
               fontWeight: FontWeight.w500,
               height: 24 / 14,
             ),
           ),
-          const SizedBox(height: 12),
+
           _buildSecurityTip('Write am down for paper, no screenshot'),
-          const SizedBox(height: 12),
-          _buildSecurityTip('Keep multiple copies for different safe\nplaces'),
-          const SizedBox(height: 12),
-          _buildSecurityTip('Never share am with anybody, even Sabi\nsupport'),
+          _buildSecurityTip('Keep multiple copies for different safe places'),
+          _buildSecurityTip('Never share am with anybody, even Sabi support'),
         ],
       ),
     );
@@ -484,18 +472,16 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
           child: SizedBox(
             width: 16,
             height: 16,
-            child: CustomPaint(
-              painter: CheckIconPainter(),
-            ),
+            child: CustomPaint(painter: CheckIconPainter()),
           ),
         ),
-        const SizedBox(width: 12),
+        SizedBox(width: 12.w),
         Expanded(
           child: Text(
             text,
             style: TextStyle(
               color: Color(0xFF9CA3AF),
-              fontSize: 12,
+              fontSize: 12.sp,
               fontWeight: FontWeight.w400,
               height: 20 / 12,
             ),
@@ -508,22 +494,22 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
   Widget _buildBottomButton() {
     return SizedBox(
       width: double.infinity,
-      height: 50,
+      height: 52.h,
       child: ElevatedButton(
         onPressed: _isRevealed ? _onWroteThemDown : null,
         style: ElevatedButton.styleFrom(
           backgroundColor: AppColors.primary,
           disabledBackgroundColor: AppColors.disabled,
-          foregroundColor: AppColors.textPrimary,
+          foregroundColor: AppColors.surface,
           elevation: 0,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: BorderRadius.circular(16.r),
           ),
         ),
-        child: const Text(
+        child: Text(
           'I Wrote Them Down',
           style: TextStyle(
-            fontSize: 14,
+            fontSize: 14.sp,
             fontWeight: FontWeight.w500,
             height: 24 / 14,
           ),
@@ -536,10 +522,7 @@ class _SeedPhraseScreenState extends ConsumerState<SeedPhraseScreen> {
 class VerifyBackupScreen extends StatefulWidget {
   final List<String> seedWords;
 
-  const VerifyBackupScreen({
-    super.key,
-    required this.seedWords,
-  });
+  const VerifyBackupScreen({super.key, required this.seedWords});
 
   @override
   State<VerifyBackupScreen> createState() => _VerifyBackupScreenState();
@@ -583,10 +566,15 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: const Text('Incorrect words. Please try again.'),
+          content: Text(
+            'Incorrect words. Please try again.',
+            style: TextStyle(color: AppColors.surface),
+          ),
           backgroundColor: AppColors.accentRed,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8.r),
+          ),
         ),
       );
     }
@@ -598,7 +586,7 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
       backgroundColor: AppColors.background,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(31, 29, 31, 30),
+          padding: EdgeInsets.fromLTRB(31.w, 29.h, 31.w, 30.h),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -607,23 +595,21 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
                   GestureDetector(
                     onTap: () => Navigator.pop(context),
                     child: SizedBox(
-                      width: 24,
-                      height: 24,
-                      child: CustomPaint(
-                        painter: BackArrowPainter(),
-                      ),
+                      width: 24.w,
+                      height: 24.h,
+                      child: CustomPaint(painter: BackArrowPainter()),
                     ),
                   ),
-                  const SizedBox(width: 10),
+                  SizedBox(width: 10.w),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Text(
+                        Text(
                           'Verify Your Backup',
                           style: TextStyle(
                             color: AppColors.textPrimary,
-                            fontSize: 18,
+                            fontSize: 18.sp,
                             fontWeight: FontWeight.w500,
                             height: 32 / 18,
                           ),
@@ -632,7 +618,7 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
                           'Enter the missing words to confirm',
                           style: TextStyle(
                             color: Color(0xFF9CA3AF),
-                            fontSize: 12,
+                            fontSize: 12.sp,
                             fontWeight: FontWeight.w400,
                             height: 20 / 12,
                           ),
@@ -642,14 +628,17 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
                   ),
                 ],
               ),
-              const SizedBox(height: 28),
+              SizedBox(height: 28.h),
               Expanded(
                 child: SingleChildScrollView(
                   child: Container(
-                    padding: const EdgeInsets.all(24),
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 24.w,
+                      vertical: 24.h,
+                    ),
                     decoration: BoxDecoration(
                       color: AppColors.surface,
-                      borderRadius: BorderRadius.circular(20),
+                      borderRadius: BorderRadius.circular(20.r),
                       boxShadow: [
                         BoxShadow(
                           color: Colors.black.withValues(alpha: 0.15),
@@ -659,32 +648,30 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
                       ],
                     ),
                     child: Column(
+                      spacing: 16.h,
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
                           'Enter the missing words to verify you wrote them down correctly',
                           style: TextStyle(
                             color: Color(0xFF9CA3AF),
-                            fontSize: 12,
+                            fontSize: 12.sp,
                             fontWeight: FontWeight.w400,
                             height: 20 / 12,
                           ),
                         ),
-                        const SizedBox(height: 16),
                         _buildWordInput('Word #3', _word3Controller),
-                        const SizedBox(height: 16),
                         _buildWordInput('Word #7', _word7Controller),
-                        const SizedBox(height: 16),
                         _buildWordInput('Word #11', _word11Controller),
                       ],
                     ),
                   ),
                 ),
               ),
-              const SizedBox(height: 24),
+              SizedBox(height: 24.h),
               SizedBox(
                 width: double.infinity,
-                height: 50,
+                height: 52.h,
                 child: ElevatedButton(
                   onPressed: _canVerify() ? _onVerify : null,
                   style: ElevatedButton.styleFrom(
@@ -693,13 +680,13 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
                     foregroundColor: AppColors.textPrimary,
                     elevation: 0,
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: BorderRadius.circular(16.r),
                     ),
                   ),
-                  child: const Text(
+                  child: Text(
                     'Verify & Continue',
                     style: TextStyle(
-                      fontSize: 14,
+                      fontSize: 14.sp,
                       fontWeight: FontWeight.w500,
                       height: 24 / 14,
                     ),
@@ -721,37 +708,37 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
           label,
           style: TextStyle(
             color: Color(0xFF9CA3AF),
-            fontSize: 12,
+            fontSize: 12.sp,
             fontWeight: FontWeight.w400,
             height: 20 / 12,
           ),
         ),
-        const SizedBox(height: 8),
+        SizedBox(height: 8.h),
         Container(
-          height: 50,
+          height: 52.h,
           decoration: BoxDecoration(
             color: AppColors.background,
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: BorderRadius.circular(16.r),
             border: Border.all(color: Color(0xFF374151), width: 1),
           ),
           child: TextField(
             controller: controller,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textPrimary,
-              fontSize: 16,
+              fontSize: 16.sp,
               fontWeight: FontWeight.w400,
             ),
             decoration: InputDecoration(
               hintText: 'Enter word',
               hintStyle: TextStyle(
                 color: Color(0xFFCCCCCC),
-                fontSize: 16,
+                fontSize: 16.sp,
                 fontWeight: FontWeight.w400,
               ),
               border: InputBorder.none,
-              contentPadding: const EdgeInsets.symmetric(
-                horizontal: 17,
-                vertical: 13,
+              contentPadding: EdgeInsets.symmetric(
+                horizontal: 17.w,
+                vertical: 13.h,
               ),
             ),
             onChanged: (_) => setState(() {}),
@@ -765,12 +752,13 @@ class _VerifyBackupScreenState extends State<VerifyBackupScreen> {
 class BackArrowPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = AppColors.textPrimary
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
+    final paint =
+        Paint()
+          ..color = AppColors.textPrimary
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round;
 
     final path = Path();
     path.moveTo(size.width * 0.5, size.width * 0.79);
@@ -793,77 +781,114 @@ class BackArrowPainter extends CustomPainter {
 class WarningIconPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = AppColors.accentRed
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
+    final paint =
+        Paint()
+          ..color = AppColors.accentRed
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round;
 
     final path = Path();
     path.moveTo(size.width * 0.906, size.width * 0.75);
     path.lineTo(size.width * 0.572, size.width * 0.167);
     path.cubicTo(
-      size.width * 0.565, size.width * 0.154,
-      size.width * 0.543, size.width * 0.145,
-      size.width * 0.540, size.width * 0.136,
+      size.width * 0.565,
+      size.width * 0.154,
+      size.width * 0.543,
+      size.width * 0.145,
+      size.width * 0.540,
+      size.width * 0.136,
     );
     path.cubicTo(
-      size.width * 0.529, size.width * 0.125,
-      size.width * 0.518, size.width * 0.124,
-      size.width * 0.495, size.width * 0.124,
+      size.width * 0.529,
+      size.width * 0.125,
+      size.width * 0.518,
+      size.width * 0.124,
+      size.width * 0.495,
+      size.width * 0.124,
     );
     path.cubicTo(
-      size.width * 0.485, size.width * 0.124,
-      size.width * 0.471, size.width * 0.125,
-      size.width * 0.458, size.width * 0.136,
+      size.width * 0.485,
+      size.width * 0.124,
+      size.width * 0.471,
+      size.width * 0.125,
+      size.width * 0.458,
+      size.width * 0.136,
     );
     path.cubicTo(
-      size.width * 0.448, size.width * 0.145,
-      size.width * 0.427, size.width * 0.154,
-      size.width * 0.427, size.width * 0.167,
+      size.width * 0.448,
+      size.width * 0.145,
+      size.width * 0.427,
+      size.width * 0.154,
+      size.width * 0.427,
+      size.width * 0.167,
     );
     path.lineTo(size.width * 0.094, size.width * 0.75);
     path.cubicTo(
-      size.width * 0.086, size.width * 0.763,
-      size.width * 0.083, size.width * 0.780,
-      size.width * 0.083, size.width * 0.794,
+      size.width * 0.086,
+      size.width * 0.763,
+      size.width * 0.083,
+      size.width * 0.780,
+      size.width * 0.083,
+      size.width * 0.794,
     );
     path.cubicTo(
-      size.width * 0.083, size.width * 0.807,
-      size.width * 0.087, size.width * 0.824,
-      size.width * 0.094, size.width * 0.837,
+      size.width * 0.083,
+      size.width * 0.807,
+      size.width * 0.087,
+      size.width * 0.824,
+      size.width * 0.094,
+      size.width * 0.837,
     );
     path.cubicTo(
-      size.width * 0.101, size.width * 0.851,
-      size.width * 0.114, size.width * 0.864,
-      size.width * 0.125, size.width * 0.874,
+      size.width * 0.101,
+      size.width * 0.851,
+      size.width * 0.114,
+      size.width * 0.864,
+      size.width * 0.125,
+      size.width * 0.874,
     );
     path.cubicTo(
-      size.width * 0.138, size.width * 0.883,
-      size.width * 0.153, size.width * 0.888,
-      size.width * 0.167, size.width * 0.875,
+      size.width * 0.138,
+      size.width * 0.883,
+      size.width * 0.153,
+      size.width * 0.888,
+      size.width * 0.167,
+      size.width * 0.875,
     );
     path.lineTo(size.width * 0.833, size.width * 0.875);
     path.cubicTo(
-      size.width * 0.848, size.width * 0.875,
-      size.width * 0.862, size.width * 0.870,
-      size.width * 0.875, size.width * 0.861,
+      size.width * 0.848,
+      size.width * 0.875,
+      size.width * 0.862,
+      size.width * 0.870,
+      size.width * 0.875,
+      size.width * 0.861,
     );
     path.cubicTo(
-      size.width * 0.888, size.width * 0.851,
-      size.width * 0.898, size.width * 0.838,
-      size.width * 0.906, size.width * 0.825,
+      size.width * 0.888,
+      size.width * 0.851,
+      size.width * 0.898,
+      size.width * 0.838,
+      size.width * 0.906,
+      size.width * 0.825,
     );
     path.cubicTo(
-      size.width * 0.913, size.width * 0.812,
-      size.width * 0.917, size.width * 0.796,
-      size.width * 0.917, size.width * 0.783,
+      size.width * 0.913,
+      size.width * 0.812,
+      size.width * 0.917,
+      size.width * 0.796,
+      size.width * 0.917,
+      size.width * 0.783,
     );
     path.cubicTo(
-      size.width * 0.917, size.width * 0.770,
-      size.width * 0.913, size.width * 0.763,
-      size.width * 0.906, size.width * 0.75,
+      size.width * 0.917,
+      size.width * 0.770,
+      size.width * 0.913,
+      size.width * 0.763,
+      size.width * 0.906,
+      size.width * 0.75,
     );
     path.close();
 
@@ -889,64 +914,91 @@ class WarningIconPainter extends CustomPainter {
 class EyeIconPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = AppColors.textPrimary
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
+    final paint =
+        Paint()
+          ..color = AppColors.surface
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round;
 
     final path1 = Path();
     path1.moveTo(size.width * 0.086, size.width * 0.515);
     path1.cubicTo(
-      size.width * 0.120, size.width * 0.403,
-      size.width * 0.177, size.width * 0.333,
-      size.width * 0.251, size.width * 0.284,
+      size.width * 0.120,
+      size.width * 0.403,
+      size.width * 0.177,
+      size.width * 0.333,
+      size.width * 0.251,
+      size.width * 0.284,
     );
     path1.cubicTo(
-      size.width * 0.325, size.width * 0.235,
-      size.width * 0.411, size.width * 0.208,
-      size.width * 0.500, size.width * 0.208,
+      size.width * 0.325,
+      size.width * 0.235,
+      size.width * 0.411,
+      size.width * 0.208,
+      size.width * 0.500,
+      size.width * 0.208,
     );
     path1.cubicTo(
-      size.width * 0.589, size.width * 0.208,
-      size.width * 0.675, size.width * 0.235,
-      size.width * 0.749, size.width * 0.284,
+      size.width * 0.589,
+      size.width * 0.208,
+      size.width * 0.675,
+      size.width * 0.235,
+      size.width * 0.749,
+      size.width * 0.284,
     );
     path1.cubicTo(
-      size.width * 0.823, size.width * 0.333,
-      size.width * 0.880, size.width * 0.403,
-      size.width * 0.914, size.width * 0.515,
+      size.width * 0.823,
+      size.width * 0.333,
+      size.width * 0.880,
+      size.width * 0.403,
+      size.width * 0.914,
+      size.width * 0.515,
     );
     path1.cubicTo(
-      size.width * 0.880, size.width * 0.597,
-      size.width * 0.823, size.width * 0.666,
-      size.width * 0.749, size.width * 0.716,
+      size.width * 0.880,
+      size.width * 0.597,
+      size.width * 0.823,
+      size.width * 0.666,
+      size.width * 0.749,
+      size.width * 0.716,
     );
     path1.cubicTo(
-      size.width * 0.675, size.width * 0.765,
-      size.width * 0.589, size.width * 0.792,
-      size.width * 0.500, size.width * 0.792,
+      size.width * 0.675,
+      size.width * 0.765,
+      size.width * 0.589,
+      size.width * 0.792,
+      size.width * 0.500,
+      size.width * 0.792,
     );
     path1.cubicTo(
-      size.width * 0.411, size.width * 0.792,
-      size.width * 0.325, size.width * 0.765,
-      size.width * 0.251, size.width * 0.716,
+      size.width * 0.411,
+      size.width * 0.792,
+      size.width * 0.325,
+      size.width * 0.765,
+      size.width * 0.251,
+      size.width * 0.716,
     );
     path1.cubicTo(
-      size.width * 0.177, size.width * 0.666,
-      size.width * 0.120, size.width * 0.597,
-      size.width * 0.086, size.width * 0.515,
+      size.width * 0.177,
+      size.width * 0.666,
+      size.width * 0.120,
+      size.width * 0.597,
+      size.width * 0.086,
+      size.width * 0.515,
     );
     path1.close();
 
     canvas.drawPath(path1, paint);
 
     final path2 = Path();
-    path2.addOval(Rect.fromCircle(
-      center: Offset(size.width * 0.5, size.width * 0.5),
-      radius: size.width * 0.125,
-    ));
+    path2.addOval(
+      Rect.fromCircle(
+        center: Offset(size.width * 0.5, size.width * 0.5),
+        radius: size.width * 0.125,
+      ),
+    );
 
     canvas.drawPath(path2, paint);
   }
@@ -958,24 +1010,31 @@ class EyeIconPainter extends CustomPainter {
 class EyeOffIconPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = AppColors.primary
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
+    final paint =
+        Paint()
+          ..color = AppColors.primary
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round;
 
     final path1 = Path();
     path1.moveTo(size.width * 0.447, size.width * 0.212);
     path1.cubicTo(
-      size.width * 0.544, size.width * 0.199,
-      size.width * 0.642, size.width * 0.205,
-      size.width * 0.727, size.width * 0.270,
+      size.width * 0.544,
+      size.width * 0.199,
+      size.width * 0.642,
+      size.width * 0.205,
+      size.width * 0.727,
+      size.width * 0.270,
     );
     path1.cubicTo(
-      size.width * 0.811, size.width * 0.319,
-      size.width * 0.868, size.width * 0.395,
-      size.width * 0.914, size.width * 0.485,
+      size.width * 0.811,
+      size.width * 0.319,
+      size.width * 0.868,
+      size.width * 0.395,
+      size.width * 0.914,
+      size.width * 0.485,
     );
 
     canvas.drawPath(path1, paint);
@@ -983,24 +1042,36 @@ class EyeOffIconPainter extends CustomPainter {
     final path2 = Path();
     path2.moveTo(size.width * 0.587, size.width * 0.590);
     path2.cubicTo(
-      size.width * 0.563, size.width * 0.613,
-      size.width * 0.532, size.width * 0.625,
-      size.width * 0.499, size.width * 0.625,
+      size.width * 0.563,
+      size.width * 0.613,
+      size.width * 0.532,
+      size.width * 0.625,
+      size.width * 0.499,
+      size.width * 0.625,
     );
     path2.cubicTo(
-      size.width * 0.466, size.width * 0.625,
-      size.width * 0.435, size.width * 0.613,
-      size.width * 0.412, size.width * 0.588,
+      size.width * 0.466,
+      size.width * 0.625,
+      size.width * 0.435,
+      size.width * 0.613,
+      size.width * 0.412,
+      size.width * 0.588,
     );
     path2.cubicTo(
-      size.width * 0.388, size.width * 0.565,
-      size.width * 0.375, size.width * 0.534,
-      size.width * 0.375, size.width * 0.501,
+      size.width * 0.388,
+      size.width * 0.565,
+      size.width * 0.375,
+      size.width * 0.534,
+      size.width * 0.375,
+      size.width * 0.501,
     );
     path2.cubicTo(
-      size.width * 0.375, size.width * 0.468,
-      size.width * 0.387, size.width * 0.437,
-      size.width * 0.410, size.width * 0.413,
+      size.width * 0.375,
+      size.width * 0.468,
+      size.width * 0.387,
+      size.width * 0.437,
+      size.width * 0.410,
+      size.width * 0.413,
     );
 
     canvas.drawPath(path2, paint);
@@ -1008,29 +1079,44 @@ class EyeOffIconPainter extends CustomPainter {
     final path3 = Path();
     path3.moveTo(size.width * 0.729, size.width * 0.729);
     path3.cubicTo(
-      size.width * 0.673, size.width * 0.762,
-      size.width * 0.611, size.width * 0.782,
-      size.width * 0.547, size.width * 0.789,
+      size.width * 0.673,
+      size.width * 0.762,
+      size.width * 0.611,
+      size.width * 0.782,
+      size.width * 0.547,
+      size.width * 0.789,
     );
     path3.cubicTo(
-      size.width * 0.484, size.width * 0.796,
-      size.width * 0.419, size.width * 0.789,
-      size.width * 0.358, size.width * 0.769,
+      size.width * 0.484,
+      size.width * 0.796,
+      size.width * 0.419,
+      size.width * 0.789,
+      size.width * 0.358,
+      size.width * 0.769,
     );
     path3.cubicTo(
-      size.width * 0.297, size.width * 0.748,
-      size.width * 0.241, size.width * 0.715,
-      size.width * 0.194, size.width * 0.671,
+      size.width * 0.297,
+      size.width * 0.748,
+      size.width * 0.241,
+      size.width * 0.715,
+      size.width * 0.194,
+      size.width * 0.671,
     );
     path3.cubicTo(
-      size.width * 0.147, size.width * 0.627,
-      size.width * 0.110, size.width * 0.574,
-      size.width * 0.086, size.width * 0.515,
+      size.width * 0.147,
+      size.width * 0.627,
+      size.width * 0.110,
+      size.width * 0.574,
+      size.width * 0.086,
+      size.width * 0.515,
     );
     path3.cubicTo(
-      size.width * 0.123, size.width * 0.396,
-      size.width * 0.188, size.width * 0.321,
-      size.width * 0.271, size.width * 0.271,
+      size.width * 0.123,
+      size.width * 0.396,
+      size.width * 0.188,
+      size.width * 0.321,
+      size.width * 0.271,
+      size.width * 0.271,
     );
 
     canvas.drawPath(path3, paint);
@@ -1049,38 +1135,51 @@ class EyeOffIconPainter extends CustomPainter {
 class CopyIconPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = AppColors.textPrimary
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
+    final paint =
+        Paint()
+          ..color = AppColors.textPrimary.withValues(alpha: 0.75)
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round;
 
     final path1 = Path();
     path1.moveTo(size.width * 0.833, size.width * 0.333);
     path1.lineTo(size.width * 0.417, size.width * 0.333);
     path1.cubicTo(
-      size.width * 0.371, size.width * 0.333,
-      size.width * 0.333, size.width * 0.371,
-      size.width * 0.333, size.width * 0.417,
+      size.width * 0.371,
+      size.width * 0.333,
+      size.width * 0.333,
+      size.width * 0.371,
+      size.width * 0.333,
+      size.width * 0.417,
     );
     path1.lineTo(size.width * 0.333, size.width * 0.833);
     path1.cubicTo(
-      size.width * 0.333, size.width * 0.879,
-      size.width * 0.371, size.width * 0.917,
-      size.width * 0.417, size.width * 0.917,
+      size.width * 0.333,
+      size.width * 0.879,
+      size.width * 0.371,
+      size.width * 0.917,
+      size.width * 0.417,
+      size.width * 0.917,
     );
     path1.lineTo(size.width * 0.833, size.width * 0.917);
     path1.cubicTo(
-      size.width * 0.879, size.width * 0.917,
-      size.width * 0.917, size.width * 0.879,
-      size.width * 0.917, size.width * 0.833,
+      size.width * 0.879,
+      size.width * 0.917,
+      size.width * 0.917,
+      size.width * 0.879,
+      size.width * 0.917,
+      size.width * 0.833,
     );
     path1.lineTo(size.width * 0.917, size.width * 0.417);
     path1.cubicTo(
-      size.width * 0.917, size.width * 0.371,
-      size.width * 0.879, size.width * 0.333,
-      size.width * 0.833, size.width * 0.333,
+      size.width * 0.917,
+      size.width * 0.371,
+      size.width * 0.879,
+      size.width * 0.333,
+      size.width * 0.833,
+      size.width * 0.333,
     );
     path1.close();
 
@@ -1089,21 +1188,30 @@ class CopyIconPainter extends CustomPainter {
     final path2 = Path();
     path2.moveTo(size.width * 0.167, size.width * 0.667);
     path2.cubicTo(
-      size.width * 0.121, size.width * 0.667,
-      size.width * 0.083, size.width * 0.629,
-      size.width * 0.083, size.width * 0.583,
+      size.width * 0.121,
+      size.width * 0.667,
+      size.width * 0.083,
+      size.width * 0.629,
+      size.width * 0.083,
+      size.width * 0.583,
     );
     path2.lineTo(size.width * 0.083, size.width * 0.167);
     path2.cubicTo(
-      size.width * 0.083, size.width * 0.121,
-      size.width * 0.121, size.width * 0.083,
-      size.width * 0.167, size.width * 0.083,
+      size.width * 0.083,
+      size.width * 0.121,
+      size.width * 0.121,
+      size.width * 0.083,
+      size.width * 0.167,
+      size.width * 0.083,
     );
     path2.lineTo(size.width * 0.583, size.width * 0.083);
     path2.cubicTo(
-      size.width * 0.629, size.width * 0.083,
-      size.width * 0.667, size.width * 0.121,
-      size.width * 0.667, size.width * 0.167,
+      size.width * 0.629,
+      size.width * 0.083,
+      size.width * 0.667,
+      size.width * 0.121,
+      size.width * 0.667,
+      size.width * 0.167,
     );
 
     canvas.drawPath(path2, paint);
@@ -1116,54 +1224,79 @@ class CopyIconPainter extends CustomPainter {
 class CheckIconPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = Color(0xFF00FFB2)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
+    final paint =
+        Paint()
+          ..color = Color(0xFF00FFB2)
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round;
 
     final path1 = Path();
     path1.moveTo(size.width * 0.908, size.width * 0.417);
     path1.cubicTo(
-      size.width * 0.927, size.width * 0.510,
-      size.width * 0.914, size.width * 0.607,
-      size.width * 0.870, size.width * 0.692,
+      size.width * 0.927,
+      size.width * 0.510,
+      size.width * 0.914,
+      size.width * 0.607,
+      size.width * 0.870,
+      size.width * 0.692,
     );
     path1.cubicTo(
-      size.width * 0.826, size.width * 0.776,
-      size.width * 0.755, size.width * 0.933,
-      size.width * 0.667, size.width * 0.878,
+      size.width * 0.826,
+      size.width * 0.776,
+      size.width * 0.755,
+      size.width * 0.933,
+      size.width * 0.667,
+      size.width * 0.878,
     );
     path1.cubicTo(
-      size.width * 0.580, size.width * 0.823,
-      size.width * 0.482, size.width * 0.894,
-      size.width * 0.390, size.width * 0.902,
+      size.width * 0.580,
+      size.width * 0.823,
+      size.width * 0.482,
+      size.width * 0.894,
+      size.width * 0.390,
+      size.width * 0.902,
     );
     path1.cubicTo(
-      size.width * 0.298, size.width * 0.910,
-      size.width * 0.218, size.width * 0.821,
-      size.width * 0.162, size.width * 0.743,
+      size.width * 0.298,
+      size.width * 0.910,
+      size.width * 0.218,
+      size.width * 0.821,
+      size.width * 0.162,
+      size.width * 0.743,
     );
     path1.cubicTo(
-      size.width * 0.106, size.width * 0.665,
-      size.width * 0.079, size.width * 0.572,
-      size.width * 0.084, size.width * 0.477,
+      size.width * 0.106,
+      size.width * 0.665,
+      size.width * 0.079,
+      size.width * 0.572,
+      size.width * 0.084,
+      size.width * 0.477,
     );
     path1.cubicTo(
-      size.width * 0.089, size.width * 0.382,
-      size.width * 0.127, size.width * 0.291,
-      size.width * 0.191, size.width * 0.220,
+      size.width * 0.089,
+      size.width * 0.382,
+      size.width * 0.127,
+      size.width * 0.291,
+      size.width * 0.191,
+      size.width * 0.220,
     );
     path1.cubicTo(
-      size.width * 0.255, size.width * 0.150,
-      size.width * 0.341, size.width * 0.103,
-      size.width * 0.435, size.width * 0.088,
+      size.width * 0.255,
+      size.width * 0.150,
+      size.width * 0.341,
+      size.width * 0.103,
+      size.width * 0.435,
+      size.width * 0.088,
     );
     path1.cubicTo(
-      size.width * 0.529, size.width * 0.073,
-      size.width * 0.632, size.width * 0.091,
-      size.width * 0.708, size.width * 0.139,
+      size.width * 0.529,
+      size.width * 0.073,
+      size.width * 0.632,
+      size.width * 0.091,
+      size.width * 0.708,
+      size.width * 0.139,
     );
 
     canvas.drawPath(path1, paint);

--- a/lib/features/profile/presentation/screens/backup_recovery_screen.dart
+++ b/lib/features/profile/presentation/screens/backup_recovery_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:sabi_wallet/core/constants/colors.dart';
 import 'package:sabi_wallet/core/services/secure_storage_service.dart';
 import 'package:sabi_wallet/features/onboarding/presentation/screens/backup_choice_screen.dart';
@@ -17,70 +18,68 @@ class BackupRecoveryScreen extends ConsumerWidget {
       backgroundColor: AppColors.background,
       body: SafeArea(
         child: SingleChildScrollView(
-          padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+          padding: EdgeInsets.fromLTRB(24.w, 24.h, 24.w, 32.h),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
-                children: [
-                  IconButton(
-                    icon: const Icon(
-                      Icons.arrow_back,
-                      color: AppColors.textPrimary,
-                    ),
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                  const SizedBox(width: 8),
-                  const Text(
-                    'Backup & Recovery',
-                    style: TextStyle(
-                      color: AppColors.textPrimary,
-                      fontSize: 20,
-                      fontWeight: FontWeight.w700,
-                      height: 1.4,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 20),
-
-              // Wallet backed up card
+              _buildHeader(context),
+              SizedBox(height: 20.h),
               _BackupStatusCard(storage: storage),
-              const SizedBox(height: 24),
-
-              const Text(
+              SizedBox(height: 24.h),
+              Text(
                 'Your Recovery Guys',
                 style: TextStyle(
                   color: AppColors.textPrimary,
-                  fontSize: 16,
+                  fontSize: 16.sp,
                   fontWeight: FontWeight.w600,
                   height: 1.5,
                 ),
               ),
-              const SizedBox(height: 16),
-
+              SizedBox(height: 16.h),
               const _HealthCard(),
-              const SizedBox(height: 16),
-
+              SizedBox(height: 16.h),
               const _SocialRecoveryCard(),
-              const SizedBox(height: 28),
-
-              const Text(
+              SizedBox(height: 28.h),
+              Text(
                 'Manual Backup',
                 style: TextStyle(
                   color: AppColors.textPrimary,
-                  fontSize: 16,
+                  fontSize: 16.sp,
                   fontWeight: FontWeight.w600,
                   height: 1.5,
                 ),
               ),
-              const SizedBox(height: 12),
-
+              SizedBox(height: 12.h),
               _ManualBackupCard(storage: storage),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Row(
+      children: [
+        IconButton(
+          icon: Icon(
+            Icons.arrow_back,
+            color: AppColors.textPrimary,
+            size: 24.sp,
+          ),
+          onPressed: () => Navigator.pop(context),
+        ),
+        SizedBox(width: 8.w),
+        Text(
+          'Backup & Recovery',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: 20.sp,
+            fontWeight: FontWeight.w700,
+            height: 1.4,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -107,17 +106,17 @@ class _BackupStatusCard extends StatelessWidget {
                 : 'Set up a backup to protect your funds';
 
         return Container(
-          padding: const EdgeInsets.all(18),
+          padding: EdgeInsets.all(18.w),
           decoration: BoxDecoration(
             color: AppColors.surface,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: borderColor, width: 1.2),
+            borderRadius: BorderRadius.circular(16.r),
+            border: Border.all(color: borderColor, width: 1.2.w),
           ),
           child: Row(
             children: [
               Container(
-                width: 44,
-                height: 44,
+                width: 44.w,
+                height: 44.w,
                 decoration: BoxDecoration(
                   color: borderColor.withValues(alpha: 0.15),
                   shape: BoxShape.circle,
@@ -125,29 +124,29 @@ class _BackupStatusCard extends StatelessWidget {
                 child: Icon(
                   Icons.shield_moon_outlined,
                   color: borderColor,
-                  size: 24,
+                  size: 24.sp,
                 ),
               ),
-              const SizedBox(width: 14),
+              SizedBox(width: 14.w),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
                       title,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textPrimary,
-                        fontSize: 16,
+                        fontSize: 16.sp,
                         fontWeight: FontWeight.w700,
                         height: 1.5,
                       ),
                     ),
-                    const SizedBox(height: 4),
+                    SizedBox(height: 4.h),
                     Text(
                       subtitle,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textSecondary,
-                        fontSize: 12,
+                        fontSize: 12.sp,
                         fontWeight: FontWeight.w400,
                         height: 1.6,
                       ),
@@ -157,18 +156,20 @@ class _BackupStatusCard extends StatelessWidget {
               ),
               if (!isBackedUp)
                 TextButton(
-                  onPressed:
-                      () => Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => const BackupChoiceScreen(),
-                        ),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const BackupChoiceScreen(),
                       ),
-                  child: const Text(
+                    );
+                  },
+                  child: Text(
                     'Set up',
                     style: TextStyle(
                       color: AppColors.primary,
                       fontWeight: FontWeight.w600,
+                      fontSize: 14.sp,
                     ),
                   ),
                 ),
@@ -186,18 +187,18 @@ class _HealthCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(18),
+      padding: EdgeInsets.all(18.w),
       decoration: BoxDecoration(
         color: AppColors.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppColors.accentGreen, width: 1.2),
+        borderRadius: BorderRadius.circular(16.r),
+        border: Border.all(color: AppColors.accentGreen, width: 1.2.w),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: [
-              const Expanded(
+              Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -205,17 +206,17 @@ class _HealthCard extends StatelessWidget {
                       'Health: Strong',
                       style: TextStyle(
                         color: AppColors.textPrimary,
-                        fontSize: 14,
+                        fontSize: 14.sp,
                         fontWeight: FontWeight.w700,
                         height: 1.5,
                       ),
                     ),
-                    SizedBox(height: 4),
+                    SizedBox(height: 4.h),
                     Text(
                       '3 contacts online last 7 days',
                       style: TextStyle(
                         color: AppColors.textSecondary,
-                        fontSize: 12,
+                        fontSize: 12.sp,
                         fontWeight: FontWeight.w400,
                         height: 1.6,
                       ),
@@ -224,30 +225,28 @@ class _HealthCard extends StatelessWidget {
                 ),
               ),
               Container(
-                width: 36,
-                height: 36,
+                width: 36.w,
+                height: 36.w,
                 decoration: BoxDecoration(
                   color: AppColors.accentGreen.withValues(alpha: 0.15),
                   shape: BoxShape.circle,
                 ),
-                child: const Icon(
+                child: Icon(
                   Icons.shield_outlined,
                   color: AppColors.accentGreen,
-                  size: 20,
+                  size: 20.sp,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 12),
+          SizedBox(height: 12.h),
           ClipRRect(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(8.r),
             child: LinearProgressIndicator(
               value: 0.85,
-              minHeight: 6,
+              minHeight: 6.h,
               backgroundColor: AppColors.surface.withValues(alpha: 0.4),
-              valueColor: const AlwaysStoppedAnimation<Color>(
-                AppColors.accentGreen,
-              ),
+              valueColor: AlwaysStoppedAnimation(AppColors.accentGreen),
             ),
           ),
         ],
@@ -268,10 +267,10 @@ class _SocialRecoveryCard extends StatelessWidget {
     ];
 
     return Container(
-      padding: const EdgeInsets.all(18),
+      padding: EdgeInsets.all(18.w),
       decoration: BoxDecoration(
         color: const Color(0xFF0B0B1C),
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(16.r),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -279,20 +278,20 @@ class _SocialRecoveryCard extends StatelessWidget {
           Row(
             children: [
               Container(
-                width: 36,
-                height: 36,
+                width: 36.w,
+                height: 36.w,
                 decoration: BoxDecoration(
                   color: AppColors.primary.withValues(alpha: 0.16),
                   shape: BoxShape.circle,
                 ),
-                child: const Icon(
+                child: Icon(
                   Icons.groups_outlined,
                   color: AppColors.primary,
-                  size: 18,
+                  size: 18.sp,
                 ),
               ),
-              const SizedBox(width: 12),
-              const Expanded(
+              SizedBox(width: 12.w),
+              Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -300,31 +299,32 @@ class _SocialRecoveryCard extends StatelessWidget {
                       'Social Recovery',
                       style: TextStyle(
                         color: AppColors.textPrimary,
-                        fontSize: 14,
+                        fontSize: 14.sp,
                         fontWeight: FontWeight.w700,
                       ),
                     ),
-                    SizedBox(height: 4),
+                    SizedBox(height: 4.h),
                     Text(
-                      '3 trusted contacts',
+                      '${contacts.length} trusted contacts',
                       style: TextStyle(
                         color: AppColors.textSecondary,
-                        fontSize: 12,
+                        fontSize: 12.sp,
                         fontWeight: FontWeight.w400,
                       ),
                     ),
                   ],
                 ),
               ),
-              const Icon(
-                Icons.keyboard_arrow_right,
-                color: AppColors.textSecondary,
-              ),
+              // Icon(
+              //   Icons.keyboard_arrow_right,
+              //   color: AppColors.textSecondary,
+              //   size: 24.sp,
+              // ),
             ],
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: 16.h),
           ...contacts.map((c) => _ContactTile(contact: c)),
-          const SizedBox(height: 16),
+          SizedBox(height: 16.h),
           Row(
             children: [
               Expanded(
@@ -338,22 +338,23 @@ class _SocialRecoveryCard extends StatelessWidget {
                     );
                   },
                   style: OutlinedButton.styleFrom(
-                    side: const BorderSide(color: AppColors.primary, width: 1),
+                    side: BorderSide(color: AppColors.primary, width: 1.w),
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
+                      borderRadius: BorderRadius.circular(12.r),
                     ),
-                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    padding: EdgeInsets.symmetric(vertical: 14.h),
                   ),
-                  child: const Text(
+                  child: Text(
                     'Manage Contacts',
                     style: TextStyle(
                       color: AppColors.primary,
                       fontWeight: FontWeight.w600,
+                      fontSize: 14.sp,
                     ),
                   ),
                 ),
               ),
-              const SizedBox(width: 12),
+              SizedBox(width: 12.w),
               Expanded(
                 child: OutlinedButton(
                   onPressed: () {
@@ -367,18 +368,19 @@ class _SocialRecoveryCard extends StatelessWidget {
                   style: OutlinedButton.styleFrom(
                     side: BorderSide(
                       color: AppColors.textSecondary.withValues(alpha: 0.4),
-                      width: 1,
+                      width: 1.w,
                     ),
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
+                      borderRadius: BorderRadius.circular(12.r),
                     ),
-                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    padding: EdgeInsets.symmetric(vertical: 14.h),
                   ),
-                  child: const Text(
+                  child: Text(
                     'Test Recovery',
                     style: TextStyle(
                       color: AppColors.textPrimary,
                       fontWeight: FontWeight.w600,
+                      fontSize: 14.sp,
                     ),
                   ),
                 ),
@@ -402,7 +404,11 @@ class _ManualBackupCard extends ConsumerWidget {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('No seed phrase found. Please set up backup first.'),
+          backgroundColor: AppColors.accentRed,
+          content: Text(
+            'No seed phrase found. Please set up backup first.',
+            style: TextStyle(color: AppColors.surface),
+          ),
           duration: Duration(seconds: 2),
         ),
       );
@@ -419,10 +425,10 @@ class _ManualBackupCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Container(
-      padding: const EdgeInsets.all(18),
+      padding: EdgeInsets.all(18.w),
       decoration: BoxDecoration(
         color: const Color(0xFF0B0B1C),
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(16.r),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -430,20 +436,20 @@ class _ManualBackupCard extends ConsumerWidget {
           Row(
             children: [
               Container(
-                width: 36,
-                height: 36,
+                width: 36.w,
+                height: 36.w,
                 decoration: BoxDecoration(
                   color: AppColors.primary.withValues(alpha: 0.16),
                   shape: BoxShape.circle,
                 ),
-                child: const Icon(
+                child: Icon(
                   Icons.key_outlined,
                   color: AppColors.primary,
-                  size: 18,
+                  size: 18.sp,
                 ),
               ),
-              const SizedBox(width: 12),
-              const Expanded(
+              SizedBox(width: 12.w),
+              Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -451,45 +457,47 @@ class _ManualBackupCard extends ConsumerWidget {
                       'Seed Phrase',
                       style: TextStyle(
                         color: AppColors.textPrimary,
-                        fontSize: 14,
+                        fontSize: 14.sp,
                         fontWeight: FontWeight.w700,
                       ),
                     ),
-                    SizedBox(height: 4),
+                    SizedBox(height: 4.h),
                     Text(
                       '12-word recovery phrase',
                       style: TextStyle(
                         color: AppColors.textSecondary,
-                        fontSize: 12,
+                        fontSize: 12.sp,
                         fontWeight: FontWeight.w400,
                       ),
                     ),
                   ],
                 ),
               ),
-              const Icon(
-                Icons.keyboard_arrow_right,
-                color: AppColors.textSecondary,
-              ),
+              // Icon(
+              //   Icons.keyboard_arrow_right,
+              //   color: AppColors.textSecondary,
+              //   size: 24.sp,
+              // ),
             ],
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: 16.h),
           SizedBox(
             width: double.infinity,
             child: OutlinedButton(
               onPressed: () => _viewSeedPhrase(context, ref),
               style: OutlinedButton.styleFrom(
-                side: const BorderSide(color: AppColors.primary, width: 1),
+                side: BorderSide(color: AppColors.primary, width: 1.w),
                 shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: BorderRadius.circular(12.r),
                 ),
-                padding: const EdgeInsets.symmetric(vertical: 14),
+                padding: EdgeInsets.symmetric(vertical: 14.h),
               ),
-              child: const Text(
+              child: Text(
                 'View Seed Phrase',
                 style: TextStyle(
                   color: AppColors.primary,
                   fontWeight: FontWeight.w600,
+                  fontSize: 14.sp,
                 ),
               ),
             ),
@@ -508,17 +516,17 @@ class _ContactTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(bottom: 10),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      margin: EdgeInsets.only(bottom: 10.h),
+      padding: EdgeInsets.symmetric(horizontal: 12.w, vertical: 10.h),
       decoration: BoxDecoration(
         color: const Color(0xFF0E1024),
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(12.r),
       ),
       child: Row(
         children: [
           Container(
-            width: 36,
-            height: 36,
+            width: 36.w,
+            height: 36.w,
             decoration: const BoxDecoration(
               color: AppColors.primary,
               shape: BoxShape.circle,
@@ -526,44 +534,40 @@ class _ContactTile extends StatelessWidget {
             child: Center(
               child: Text(
                 contact.initial,
-                style: const TextStyle(
+                style: TextStyle(
                   color: Colors.white,
                   fontWeight: FontWeight.w700,
-                  fontSize: 14,
+                  fontSize: 14.sp,
                 ),
               ),
             ),
           ),
-          const SizedBox(width: 12),
+          SizedBox(width: 12.w),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
                   contact.name,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textPrimary,
-                    fontSize: 13,
+                    fontSize: 13.sp,
                     fontWeight: FontWeight.w600,
                   ),
                 ),
-                const SizedBox(height: 2),
+                SizedBox(height: 2.h),
                 Text(
                   contact.lastActive,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
-                    fontSize: 11,
+                    fontSize: 11.sp,
                     fontWeight: FontWeight.w400,
                   ),
                 ),
               ],
             ),
           ),
-          const Icon(
-            Icons.check_circle,
-            color: AppColors.accentGreen,
-            size: 20,
-          ),
+          Icon(Icons.check_circle, color: AppColors.accentGreen, size: 20.sp),
         ],
       ),
     );

--- a/lib/features/profile/presentation/screens/change_pin_screen.dart
+++ b/lib/features/profile/presentation/screens/change_pin_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:sabi_wallet/core/constants/colors.dart';
 import 'package:sabi_wallet/core/services/secure_storage_service.dart';
 
@@ -178,23 +179,24 @@ class _ChangePinScreenState extends ConsumerState<ChangePinScreen> {
           children: [
             // Header
             Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 20),
+              padding: EdgeInsets.symmetric(vertical: 20.h, horizontal: 20.w),
               child: Row(
                 children: [
                   IconButton(
-                    icon: const Icon(
+                    icon: Icon(
                       Icons.arrow_back,
                       color: AppColors.textPrimary,
+                      size: 25.sp,
                     ),
                     onPressed: () => Navigator.pop(context),
                   ),
-                  const SizedBox(width: 8),
+                  SizedBox(width: 8.w),
                   Text(
                     widget.isCreate ? 'Create PIN' : 'Change PIN',
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textPrimary,
                       fontFamily: 'Inter',
-                      fontSize: 20,
+                      fontSize: 20.sp,
                       fontWeight: FontWeight.w700,
                       height: 1.4,
                     ),
@@ -205,7 +207,7 @@ class _ChangePinScreenState extends ConsumerState<ChangePinScreen> {
 
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 30),
+                padding: EdgeInsets.symmetric(horizontal: 30.w),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
@@ -214,27 +216,27 @@ class _ChangePinScreenState extends ConsumerState<ChangePinScreen> {
                     // Title
                     Text(
                       _title,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textPrimary,
                         fontFamily: 'Inter',
-                        fontSize: 24,
+                        fontSize: 24.sp,
                         fontWeight: FontWeight.w700,
                       ),
                     ),
-                    const SizedBox(height: 12),
+                    SizedBox(height: 12.h),
 
                     // Subtitle
                     Text(
                       _subtitle,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textSecondary,
                         fontFamily: 'Inter',
-                        fontSize: 14,
+                        fontSize: 14.sp,
                         fontWeight: FontWeight.w400,
                       ),
                       textAlign: TextAlign.center,
                     ),
-                    const SizedBox(height: 40),
+                    SizedBox(height: 30.h),
 
                     // PIN Dots
                     Row(
@@ -242,9 +244,9 @@ class _ChangePinScreenState extends ConsumerState<ChangePinScreen> {
                       children: List.generate(4, (index) {
                         final isFilled = index < _currentPinInput.length;
                         return Container(
-                          margin: const EdgeInsets.symmetric(horizontal: 8),
-                          width: 16,
-                          height: 16,
+                          margin: EdgeInsets.symmetric(horizontal: 8.w),
+                          width: 16.w,
+                          height: 16.h,
                           decoration: BoxDecoration(
                             shape: BoxShape.circle,
                             color:
@@ -264,17 +266,17 @@ class _ChangePinScreenState extends ConsumerState<ChangePinScreen> {
                     ),
 
                     // Error Message
-                    const SizedBox(height: 20),
+                    SizedBox(height: 20.h),
                     SizedBox(
-                      height: 20,
+                      height: 20.h,
                       child:
                           _errorMessage.isNotEmpty
                               ? Text(
                                 _errorMessage,
-                                style: const TextStyle(
+                                style: TextStyle(
                                   color: AppColors.accentRed,
                                   fontFamily: 'Inter',
-                                  fontSize: 14,
+                                  fontSize: 14.sp,
                                   fontWeight: FontWeight.w400,
                                 ),
                               )
@@ -289,7 +291,7 @@ class _ChangePinScreenState extends ConsumerState<ChangePinScreen> {
                       onDeletePressed: _onDeletePressed,
                     ),
 
-                    const SizedBox(height: 40),
+                    SizedBox(height: 40.h),
                   ],
                 ),
               ),
@@ -313,25 +315,25 @@ class _NumberPad extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
+      spacing: 16.h,
       children: [
         _buildNumberRow(['1', '2', '3']),
-        const SizedBox(height: 16),
         _buildNumberRow(['4', '5', '6']),
-        const SizedBox(height: 16),
         _buildNumberRow(['7', '8', '9']),
-        const SizedBox(height: 16),
+
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            const SizedBox(width: 80, height: 80), // Empty space
+            SizedBox(width: 80.w, height: 80.h), // Empty space
             _NumberButton(number: '0', onPressed: () => onNumberPressed('0')),
             SizedBox(
-              width: 80,
-              height: 80,
+              width: 80.w,
+              height: 80.h,
               child: IconButton(
-                icon: const Icon(
+                icon: Icon(
                   Icons.backspace_outlined,
                   color: AppColors.textPrimary,
+                  size: 25.sp,
                 ),
                 onPressed: onDeletePressed,
               ),
@@ -367,8 +369,8 @@ class _NumberButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 80,
-      height: 80,
+      width: 80.w,
+      height: 80.h,
       child: TextButton(
         onPressed: onPressed,
         style: TextButton.styleFrom(
@@ -377,10 +379,10 @@ class _NumberButton extends StatelessWidget {
         ),
         child: Text(
           number,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textPrimary,
             fontFamily: 'Inter',
-            fontSize: 24,
+            fontSize: 24.sp,
             fontWeight: FontWeight.w600,
           ),
         ),

--- a/lib/features/profile/presentation/screens/edit_profile_screen.dart
+++ b/lib/features/profile/presentation/screens/edit_profile_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:sabi_wallet/core/constants/colors.dart';
 import 'package:sabi_wallet/services/profile_service.dart';
@@ -52,7 +53,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       );
 
       if (image != null) {
-        // Copy to app directory
         final appDir = await getApplicationDocumentsDirectory();
         final fileName =
             'profile_${DateTime.now().millisecondsSinceEpoch}${path.extension(image.path)}';
@@ -67,8 +67,11 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Failed to pick image: $e'),
-          backgroundColor: AppColors.surface,
+          content: Text(
+            'Failed to pick image: $e',
+            style: TextStyle(color: AppColors.surface),
+          ),
+          backgroundColor: AppColors.accentRed,
         ),
       );
     }
@@ -84,7 +87,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       );
 
       if (photo != null) {
-        // Copy to app directory
         final appDir = await getApplicationDocumentsDirectory();
         final fileName =
             'profile_${DateTime.now().millisecondsSinceEpoch}${path.extension(photo.path)}';
@@ -99,8 +101,11 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Failed to take photo: $e'),
-          backgroundColor: AppColors.surface,
+          content: Text(
+            'Failed to take photo: $e',
+            style: TextStyle(color: AppColors.surface),
+          ),
+          backgroundColor: AppColors.accentRed,
         ),
       );
     }
@@ -110,33 +115,34 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     showModalBottomSheet(
       context: context,
       backgroundColor: AppColors.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20.r)),
       ),
       builder:
           (context) => SafeArea(
             child: Padding(
-              padding: const EdgeInsets.all(20),
+              padding: EdgeInsets.all(20.w),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const Text(
+                  Text(
                     'Choose Profile Picture',
                     style: TextStyle(
                       color: Colors.white,
-                      fontSize: 18,
+                      fontSize: 18.sp,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
-                  const SizedBox(height: 20),
+                  SizedBox(height: 20.h),
                   ListTile(
-                    leading: const Icon(
-                      Icons.photo_library,
+                    leading: Icon(
+                      Icons.photo_library_outlined,
                       color: AppColors.primary,
+                      size: 24.sp,
                     ),
-                    title: const Text(
+                    title: Text(
                       'Choose from Gallery',
-                      style: TextStyle(color: Colors.white),
+                      style: TextStyle(color: Colors.white, fontSize: 16.sp),
                     ),
                     onTap: () {
                       Navigator.pop(context);
@@ -144,13 +150,14 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                     },
                   ),
                   ListTile(
-                    leading: const Icon(
+                    leading: Icon(
                       Icons.camera_alt,
                       color: AppColors.primary,
+                      size: 24.sp,
                     ),
-                    title: const Text(
+                    title: Text(
                       'Take a Photo',
-                      style: TextStyle(color: Colors.white),
+                      style: TextStyle(color: Colors.white, fontSize: 16.sp),
                     ),
                     onTap: () {
                       Navigator.pop(context);
@@ -159,10 +166,14 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                   ),
                   if (_profilePicturePath != null)
                     ListTile(
-                      leading: const Icon(Icons.delete, color: Colors.red),
-                      title: const Text(
+                      leading: Icon(
+                        Icons.delete,
+                        color: Colors.red,
+                        size: 24.sp,
+                      ),
+                      title: Text(
                         'Remove Picture',
-                        style: TextStyle(color: Colors.red),
+                        style: TextStyle(color: Colors.red, fontSize: 16.sp),
                       ),
                       onTap: () {
                         Navigator.pop(context);
@@ -193,19 +204,25 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       if (!mounted) return;
 
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('Profile updated successfully'),
+        SnackBar(
+          content: Text(
+            'Profile updated successfully',
+            style: TextStyle(fontSize: 14.sp, color: AppColors.surface),
+          ),
           backgroundColor: AppColors.accentGreen,
         ),
       );
 
-      Navigator.pop(context, true); // Return true to indicate update
+      Navigator.pop(context, true);
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Failed to update profile: $e'),
-          backgroundColor: AppColors.surface,
+          content: Text(
+            'Failed to update profile: $e',
+            style: TextStyle(fontSize: 14.sp, color: AppColors.surface),
+          ),
+          backgroundColor: AppColors.accentRed,
         ),
       );
     } finally {
@@ -223,17 +240,17 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             _buildHeader(),
             Expanded(
               child: SingleChildScrollView(
-                padding: const EdgeInsets.all(30),
+                padding: EdgeInsets.all(30.w),
                 child: Form(
                   key: _formKey,
                   child: Column(
                     children: [
                       _buildProfilePicture(),
-                      const SizedBox(height: 40),
+                      SizedBox(height: 40.h),
                       _buildNameField(),
-                      const SizedBox(height: 20),
+                      SizedBox(height: 20.h),
                       _buildUsernameField(),
-                      const SizedBox(height: 40),
+                      SizedBox(height: 40.h),
                       _buildSaveButton(),
                     ],
                   ),
@@ -248,19 +265,19 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
 
   Widget _buildHeader() {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 20, 20, 20),
+      padding: EdgeInsets.fromLTRB(20.w, 20.h, 20.w, 20.h),
       child: Row(
         children: [
           IconButton(
-            icon: const Icon(Icons.arrow_back, color: Colors.white),
+            icon: Icon(Icons.arrow_back, color: Colors.white, size: 24.sp),
             onPressed: () => Navigator.pop(context),
           ),
-          const SizedBox(width: 10),
-          const Text(
+          SizedBox(width: 10.w),
+          Text(
             'Edit Profile',
             style: TextStyle(
               color: Colors.white,
-              fontSize: 20,
+              fontSize: 20.sp,
               fontWeight: FontWeight.w600,
             ),
           ),
@@ -275,8 +292,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       child: Stack(
         children: [
           Container(
-            width: 120,
-            height: 120,
+            width: 140.w,
+            height: 140.w,
             decoration: BoxDecoration(
               color: AppColors.primary,
               shape: BoxShape.circle,
@@ -294,10 +311,10 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                       child: Text(
                         _nameController.text.isNotEmpty
                             ? _nameController.text[0].toUpperCase()
-                            : 'U',
-                        style: const TextStyle(
+                            : 'User',
+                        style: TextStyle(
                           color: Colors.white,
-                          fontSize: 48,
+                          fontSize: 48.sp,
                           fontWeight: FontWeight.w700,
                         ),
                       ),
@@ -308,17 +325,17 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             bottom: 0,
             right: 0,
             child: Container(
-              width: 36,
-              height: 36,
+              width: 36.w,
+              height: 36.w,
               decoration: BoxDecoration(
                 color: AppColors.primary,
                 shape: BoxShape.circle,
-                border: Border.all(color: AppColors.background, width: 3),
+                border: Border.all(color: AppColors.background, width: 3.w),
               ),
-              child: const Icon(
+              child: Icon(
                 Icons.camera_alt,
-                color: Colors.white,
-                size: 18,
+                color: AppColors.surface,
+                size: 18.sp,
               ),
             ),
           ),
@@ -331,30 +348,33 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
+        Text(
           'Full Name',
           style: TextStyle(
             color: AppColors.textSecondary,
-            fontSize: 14,
+            fontSize: 14.sp,
             fontWeight: FontWeight.w500,
           ),
         ),
-        const SizedBox(height: 8),
+        SizedBox(height: 8.h),
         TextFormField(
           controller: _nameController,
-          style: const TextStyle(color: Colors.white, fontSize: 16),
+          style: TextStyle(color: Colors.white, fontSize: 16.sp),
           decoration: InputDecoration(
             hintText: 'Enter your full name',
-            hintStyle: const TextStyle(color: AppColors.textTertiary),
+            hintStyle: TextStyle(
+              color: AppColors.textTertiary,
+              fontSize: 14.sp,
+            ),
             filled: true,
             fillColor: AppColors.surface,
             border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
+              borderRadius: BorderRadius.circular(16.r),
               borderSide: BorderSide.none,
             ),
-            contentPadding: const EdgeInsets.symmetric(
-              horizontal: 20,
-              vertical: 16,
+            contentPadding: EdgeInsets.symmetric(
+              horizontal: 20.w,
+              vertical: 16.h,
             ),
           ),
           validator: (value) {
@@ -366,7 +386,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             }
             return null;
           },
-          onChanged: (value) => setState(() {}), // Update initial
+          onChanged: (value) => setState(() {}),
         ),
       ],
     );
@@ -376,36 +396,36 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
+        Text(
           'Username',
           style: TextStyle(
             color: AppColors.textSecondary,
-            fontSize: 14,
+            fontSize: 14.sp,
             fontWeight: FontWeight.w500,
           ),
         ),
-        const SizedBox(height: 8),
+        SizedBox(height: 8.h),
         TextFormField(
           controller: _usernameController,
-          style: const TextStyle(color: Colors.white, fontSize: 16),
+          style: TextStyle(color: Colors.white, fontSize: 16.sp),
           decoration: InputDecoration(
             hintText: 'Enter username',
-            hintStyle: const TextStyle(color: AppColors.textTertiary),
+            hintStyle: TextStyle(
+              color: AppColors.textTertiary,
+              fontSize: 14.sp,
+            ),
             filled: true,
             fillColor: AppColors.surface,
             border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(16),
+              borderRadius: BorderRadius.circular(16.r),
               borderSide: BorderSide.none,
             ),
-            contentPadding: const EdgeInsets.symmetric(
-              horizontal: 20,
-              vertical: 16,
+            contentPadding: EdgeInsets.symmetric(
+              horizontal: 20.w,
+              vertical: 16.h,
             ),
             prefixText: '@sabi/',
-            prefixStyle: const TextStyle(
-              color: AppColors.primary,
-              fontSize: 16,
-            ),
+            prefixStyle: TextStyle(color: AppColors.primary, fontSize: 16.sp),
           ),
           validator: (value) {
             if (value == null || value.trim().isEmpty) {
@@ -420,10 +440,10 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
             return null;
           },
         ),
-        const SizedBox(height: 8),
+        SizedBox(height: 8.h),
         Text(
           'Your unique Sabi wallet address: @sabi/${_usernameController.text}',
-          style: const TextStyle(color: AppColors.textTertiary, fontSize: 12),
+          style: TextStyle(color: AppColors.textTertiary, fontSize: 12.sp),
         ),
       ],
     );
@@ -432,31 +452,31 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   Widget _buildSaveButton() {
     return SizedBox(
       width: double.infinity,
-      height: 50,
+      height: 52.h,
       child: ElevatedButton(
         onPressed: _isSaving ? null : _saveProfile,
         style: ElevatedButton.styleFrom(
           backgroundColor: AppColors.primary,
-          disabledBackgroundColor: AppColors.primary.withOpacity(0.5),
+          disabledBackgroundColor: AppColors.primary.withValues(alpha: 0.5),
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: BorderRadius.circular(16.r),
           ),
         ),
         child:
             _isSaving
-                ? const SizedBox(
-                  width: 20,
-                  height: 20,
+                ? SizedBox(
+                  width: 20.w,
+                  height: 20.h,
                   child: CircularProgressIndicator(
                     color: Colors.white,
-                    strokeWidth: 2,
+                    strokeWidth: 2.sp,
                   ),
                 )
-                : const Text(
+                : Text(
                   'Save Changes',
                   style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
+                    color: AppColors.surface,
+                    fontSize: 16.sp,
                     fontWeight: FontWeight.w600,
                   ),
                 ),

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:sabi_wallet/core/constants/colors.dart';
 import 'package:sabi_wallet/features/profile/presentation/screens/backup_recovery_screen.dart';
 import 'package:sabi_wallet/features/profile/presentation/screens/settings_screen.dart';
@@ -52,27 +53,33 @@ class _ProfileScreenState extends State<ProfileScreen> {
   Future<void> _switchWallet() async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Switch Wallet?'),
-        content: const Text(
-          'This will take you back to the wallet selection screen. Your wallet data will remain secure.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
+      builder:
+          (context) => AlertDialog(
+            title: Text('Switch Wallet?', style: TextStyle(fontSize: 18.sp)),
+            content: Text(
+              'This will take you back to the wallet selection screen. Your wallet data will remain secure.',
+              style: TextStyle(fontSize: 14.sp),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: Text('Cancel', style: TextStyle(fontSize: 14.sp)),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: Text(
+                  'Switch',
+                  style: TextStyle(color: Colors.red, fontSize: 14.sp),
+                ),
+              ),
+            ],
           ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Switch', style: TextStyle(color: Colors.red)),
-          ),
-        ],
-      ),
     );
 
     if (confirmed == true && mounted) {
-      // Go back to entry screen
-      Navigator.of(context).pushNamedAndRemoveUntil('/splash', (route) => false);
+      Navigator.of(
+        context,
+      ).pushNamedAndRemoveUntil('/splash', (route) => false);
     }
   }
 
@@ -94,38 +101,39 @@ class _ProfileScreenState extends State<ProfileScreen> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(30, 30, 30, 30),
+            padding: EdgeInsets.fromLTRB(30.w, 30.h, 30.w, 30.h),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text(
+                Text(
                   'Profile',
                   style: TextStyle(
                     color: AppColors.textPrimary,
                     fontFamily: 'Inter',
-                    fontSize: 20,
+                    fontSize: 20.sp,
                     fontWeight: FontWeight.w700,
                     height: 1.4,
                   ),
                 ),
-                const SizedBox(height: 30),
+                SizedBox(height: 30.h),
+
                 // Profile Card
                 Container(
                   width: double.infinity,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 24,
-                    vertical: 32,
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 24.w,
+                    vertical: 32.h,
                   ),
                   decoration: BoxDecoration(
                     color: AppColors.surface,
-                    borderRadius: BorderRadius.circular(20),
+                    borderRadius: BorderRadius.circular(20.r),
                   ),
                   child: Column(
                     children: [
                       // Avatar
                       Container(
-                        width: 80,
-                        height: 80,
+                        width: 80.w,
+                        height: 80.w,
                         decoration: BoxDecoration(
                           color: AppColors.primary,
                           shape: BoxShape.circle,
@@ -144,60 +152,64 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 ? Center(
                                   child: Text(
                                     profile.initial,
-                                    style: const TextStyle(
+                                    style: TextStyle(
                                       color: Colors.white,
                                       fontFamily: 'Inter',
-                                      fontSize: 32,
+                                      fontSize: 32.sp,
                                       fontWeight: FontWeight.w700,
                                     ),
                                   ),
                                 )
                                 : null,
                       ),
-                      const SizedBox(height: 16),
+                      SizedBox(height: 16.h),
+
                       // Name
                       Text(
                         profile.fullName,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textPrimary,
                           fontFamily: 'Inter',
-                          fontSize: 20,
+                          fontSize: 20.sp,
                           fontWeight: FontWeight.w600,
                         ),
                       ),
-                      const SizedBox(height: 8),
+                      SizedBox(height: 8.h),
+
                       // Username
                       Text(
                         profile.sabiUsername,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textSecondary,
                           fontFamily: 'Inter',
-                          fontSize: 14,
+                          fontSize: 14.sp,
                           fontWeight: FontWeight.w400,
                         ),
                       ),
-                      const SizedBox(height: 24),
+
+                      SizedBox(height: 24.h),
+
                       // Edit Profile Button
                       SizedBox(
                         width: double.infinity,
                         child: OutlinedButton(
                           onPressed: _navigateToEditProfile,
                           style: OutlinedButton.styleFrom(
-                            side: const BorderSide(
+                            side: BorderSide(
                               color: AppColors.primary,
-                              width: 1,
+                              width: 1.w,
                             ),
                             shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(16),
+                              borderRadius: BorderRadius.circular(16.r),
                             ),
-                            padding: const EdgeInsets.symmetric(vertical: 16),
+                            padding: EdgeInsets.symmetric(vertical: 16.h),
                           ),
-                          child: const Text(
+                          child: Text(
                             'Edit Profile',
                             style: TextStyle(
                               color: AppColors.primary,
                               fontFamily: 'Inter',
-                              fontSize: 14,
+                              fontSize: 14.sp,
                               fontWeight: FontWeight.w500,
                             ),
                           ),
@@ -206,7 +218,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     ],
                   ),
                 ),
-                const SizedBox(height: 24),
+
+                SizedBox(height: 24.h),
+
                 // Menu Items
                 _MenuItemTile(
                   icon: Icons.settings_outlined,
@@ -219,7 +233,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     );
                   },
                 ),
-                const SizedBox(height: 12),
+                SizedBox(height: 12.h),
+
                 _MenuItemTile(
                   icon: Icons.shield_outlined,
                   iconColor: AppColors.accentYellow,
@@ -233,25 +248,24 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     );
                   },
                 ),
-                const SizedBox(height: 12),
+                SizedBox(height: 12.h),
+
                 _MenuItemTile(
                   icon: Icons.people_outline,
                   iconColor: AppColors.accentGreen,
                   title: 'Agent Mode',
-                  onTap: () {
-                    // TODO: Navigate to agent mode screen
-                  },
+                  onTap: () {},
                 ),
-                const SizedBox(height: 12),
+                SizedBox(height: 12.h),
+
                 _MenuItemTile(
                   icon: Icons.card_giftcard_outlined,
                   iconColor: AppColors.accentRed,
                   title: 'Earn Rewards',
-                  onTap: () {
-                    // TODO: Navigate to earn rewards screen
-                  },
+                  onTap: () {},
                 ),
-                const SizedBox(height: 12),
+                SizedBox(height: 12.h),
+
                 _MenuItemTile(
                   icon: Icons.swap_horiz,
                   iconColor: Colors.orange,
@@ -284,32 +298,32 @@ class _MenuItemTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(20),
+      borderRadius: BorderRadius.circular(20.r),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 16.h),
         decoration: BoxDecoration(
           color: AppColors.surface,
-          borderRadius: BorderRadius.circular(20),
+          borderRadius: BorderRadius.circular(20.r),
         ),
         child: Row(
           children: [
-            Icon(icon, color: iconColor, size: 24),
-            const SizedBox(width: 16),
+            Icon(icon, color: iconColor, size: 24.sp),
+            SizedBox(width: 16.w),
             Expanded(
               child: Text(
                 title,
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textPrimary,
                   fontFamily: 'Inter',
-                  fontSize: 16,
+                  fontSize: 16.sp,
                   fontWeight: FontWeight.w400,
                 ),
               ),
             ),
-            const Icon(
+            Icon(
               Icons.chevron_right,
               color: AppColors.textSecondary,
-              size: 24,
+              size: 24.sp,
             ),
           ],
         ),

--- a/lib/features/profile/presentation/screens/settings_screen.dart
+++ b/lib/features/profile/presentation/screens/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:sabi_wallet/core/constants/colors.dart';
 import 'package:sabi_wallet/core/services/secure_storage_service.dart';
 import 'package:sabi_wallet/features/profile/presentation/screens/change_pin_screen.dart';
@@ -42,23 +43,24 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           children: [
             // Header
             Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 20),
+              padding: EdgeInsets.fromLTRB(20.w, 20.h, 20.w, 20.h),
               child: Row(
                 children: [
                   IconButton(
-                    icon: const Icon(
+                    icon: Icon(
                       Icons.arrow_back,
                       color: AppColors.textPrimary,
+                      size: 24.sp,
                     ),
                     onPressed: () => Navigator.pop(context),
                   ),
-                  const SizedBox(width: 8),
+                  SizedBox(width: 8.w),
                   Text(
                     AppLocalizations.of(context)!.settings,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textPrimary,
                       fontFamily: 'Inter',
-                      fontSize: 20,
+                      fontSize: 20.sp,
                       fontWeight: FontWeight.w700,
                       height: 1.4,
                     ),
@@ -66,16 +68,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ],
               ),
             ),
-            // Settings Content
+
+            // Content
             Expanded(
               child: SingleChildScrollView(
-                padding: const EdgeInsets.fromLTRB(30, 10, 30, 30),
+                padding: EdgeInsets.fromLTRB(30.w, 10.h, 30.w, 30.h),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // Account Section
-                    _SectionHeader(title: AppLocalizations.of(context)!.account),
-                    const SizedBox(height: 12),
+                    _SectionHeader(
+                      title: AppLocalizations.of(context)!.account,
+                    ),
+                    SizedBox(height: 12.h),
+
                     _SettingTile(
                       icon: Icons.lock_outline,
                       iconColor: AppColors.primary,
@@ -88,81 +93,84 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                                 (_) => ChangePinScreen(isCreate: !_hasPinCode),
                           ),
                         );
-                        // Recheck PIN status after returning
                         _checkPinCode();
                       },
                     ),
-                    const SizedBox(height: 12),
+
+                    SizedBox(height: 12.h),
+
                     _SettingToggleTile(
                       icon: Icons.fingerprint,
                       iconColor: AppColors.accentGreen,
                       title: 'Biometric Login',
                       value: settings.biometricEnabled,
-                      onChanged: (value) {
-                        ref
-                            .read(settingsNotifierProvider.notifier)
-                            .toggleBiometric(value);
-                      },
+                      onChanged:
+                          (value) => ref
+                              .read(settingsNotifierProvider.notifier)
+                              .toggleBiometric(value),
                     ),
-                    const SizedBox(height: 12),
+
+                    SizedBox(height: 12.h),
+
                     _SettingValueTile(
                       icon: Icons.currency_exchange,
                       iconColor: AppColors.accentYellow,
                       title: 'Currency Preference',
                       value: settings.currency,
-                      onTap: () {
-                        _showCurrencyPicker(context, ref);
-                      },
+                      onTap: () => _showCurrencyPicker(context, ref),
                     ),
-                    const SizedBox(height: 32),
 
-                    // Security Section
-                    _SectionHeader(title: AppLocalizations.of(context)!.security),
-                    const SizedBox(height: 12),
+                    SizedBox(height: 32.h),
+
+                    _SectionHeader(
+                      title: AppLocalizations.of(context)!.security,
+                    ),
+                    SizedBox(height: 12.h),
+
                     _SettingValueTile(
                       icon: Icons.account_balance_wallet_outlined,
                       iconColor: AppColors.accentRed,
                       title: 'Transaction Limits',
                       value: settings.transactionLimit,
-                      onTap: () {
-                        _showTransactionLimitPicker(context, ref);
-                      },
+                      onTap: () => _showTransactionLimitPicker(context, ref),
                     ),
-                    const SizedBox(height: 32),
 
-                    // Preferences Section
-                    _SectionHeader(title: AppLocalizations.of(context)!.preferences),
-                    const SizedBox(height: 12),
+                    SizedBox(height: 32.h),
+
+                    _SectionHeader(
+                      title: AppLocalizations.of(context)!.preferences,
+                    ),
+                    SizedBox(height: 12.h),
+
                     _SettingValueTile(
                       icon: Icons.language_outlined,
                       iconColor: AppColors.primary,
                       title: 'Language',
                       value: settings.language,
-                      onTap: () {
-                        _showLanguagePicker(context, ref);
-                      },
+                      onTap: () => _showLanguagePicker(context, ref),
                     ),
-                    const SizedBox(height: 12),
+
+                    SizedBox(height: 12.h),
+
                     _SettingToggleTile(
                       icon: Icons.notifications_outlined,
                       iconColor: AppColors.accentYellow,
                       title: 'Notifications',
                       value: settings.notificationsEnabled,
-                      onChanged: (value) {
-                        ref
-                            .read(settingsNotifierProvider.notifier)
-                            .toggleNotifications(value);
-                      },
+                      onChanged:
+                          (value) => ref
+                              .read(settingsNotifierProvider.notifier)
+                              .toggleNotifications(value),
                     ),
-                    const SizedBox(height: 12),
+
+                    SizedBox(height: 12.h),
+
                     _SettingValueTile(
                       icon: Icons.speed_outlined,
                       iconColor: AppColors.accentGreen,
                       title: 'Network Fees',
                       value: settings.networkFee,
-                      onTap: () {
-                        _showNetworkFeePicker(context, ref);
-                      },
+                      onTap: () => _showNetworkFeePicker(context, ref),
                     ),
                   ],
                 ),
@@ -174,28 +182,33 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     );
   }
 
+  // Bottom sheets remain structurally same—just scaled
+
   void _showCurrencyPicker(BuildContext context, WidgetRef ref) {
     final currencies = ['NGN', 'USD', 'EUR', 'GBP'];
     showModalBottomSheet(
       context: context,
       backgroundColor: AppColors.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20.r)),
       ),
       builder:
-          (context) => Padding(
-            padding: const EdgeInsets.symmetric(vertical: 20),
+          (_) => Padding(
+            padding: EdgeInsets.symmetric(vertical: 20.h),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 20.w,
+                    vertical: 10.h,
+                  ),
                   child: Text(
                     'Select Currency',
                     style: TextStyle(
                       color: AppColors.textPrimary,
                       fontFamily: 'Inter',
-                      fontSize: 18,
+                      fontSize: 18.sp,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
@@ -205,15 +218,18 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   (currency) => ListTile(
                     title: Text(
                       currency,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textPrimary,
-                        fontFamily: 'Inter',
-                        fontSize: 16,
+                        fontSize: 16.sp,
                       ),
                     ),
                     trailing:
                         ref.watch(settingsNotifierProvider).currency == currency
-                            ? const Icon(Icons.check, color: AppColors.primary)
+                            ? Icon(
+                              Icons.check,
+                              color: AppColors.primary,
+                              size: 22.sp,
+                            )
                             : null,
                     onTap: () {
                       ref
@@ -234,23 +250,25 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     showModalBottomSheet(
       context: context,
       backgroundColor: AppColors.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20.r)),
       ),
       builder:
-          (context) => Padding(
-            padding: const EdgeInsets.symmetric(vertical: 20),
+          (_) => Padding(
+            padding: EdgeInsets.symmetric(vertical: 20.h),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 20.w,
+                    vertical: 10.h,
+                  ),
                   child: Text(
                     'Transaction Limit',
                     style: TextStyle(
                       color: AppColors.textPrimary,
-                      fontFamily: 'Inter',
-                      fontSize: 18,
+                      fontSize: 18.sp,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
@@ -260,16 +278,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   (limit) => ListTile(
                     title: Text(
                       limit,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textPrimary,
-                        fontFamily: 'Inter',
-                        fontSize: 16,
+                        fontSize: 16.sp,
                       ),
                     ),
                     trailing:
                         ref.watch(settingsNotifierProvider).transactionLimit ==
                                 limit
-                            ? const Icon(Icons.check, color: AppColors.primary)
+                            ? Icon(
+                              Icons.check,
+                              color: AppColors.primary,
+                              size: 22.sp,
+                            )
                             : null,
                     onTap: () {
                       ref
@@ -290,23 +311,25 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     showModalBottomSheet(
       context: context,
       backgroundColor: AppColors.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20.r)),
       ),
       builder:
-          (context) => Padding(
-            padding: const EdgeInsets.symmetric(vertical: 20),
+          (_) => Padding(
+            padding: EdgeInsets.symmetric(vertical: 20.h),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 20.w,
+                    vertical: 10.h,
+                  ),
                   child: Text(
                     'Select Language',
                     style: TextStyle(
                       color: AppColors.textPrimary,
-                      fontFamily: 'Inter',
-                      fontSize: 18,
+                      fontSize: 18.sp,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
@@ -316,24 +339,24 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   (language) => ListTile(
                     title: Text(
                       language,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textPrimary,
-                        fontFamily: 'Inter',
-                        fontSize: 16,
+                        fontSize: 16.sp,
                       ),
                     ),
                     trailing:
                         ref.watch(settingsNotifierProvider).language == language
-                            ? const Icon(Icons.check, color: AppColors.primary)
+                            ? Icon(
+                              Icons.check,
+                              color: AppColors.primary,
+                              size: 22.sp,
+                            )
                             : null,
                     onTap: () {
                       ref
                           .read(settingsNotifierProvider.notifier)
                           .setLanguage(language);
-                      // Also update the app locale
-                      ref
-                          .read(languageProvider.notifier)
-                          .setLanguage(language);
+                      ref.read(languageProvider.notifier).setLanguage(language);
                       Navigator.pop(context);
                     },
                   ),
@@ -350,26 +373,29 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       {'label': 'Standard', 'subtitle': 'Balanced fee and speed'},
       {'label': 'Priority', 'subtitle': 'Higher fee, faster confirmation'},
     ];
+
     showModalBottomSheet(
       context: context,
       backgroundColor: AppColors.surface,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20.r)),
       ),
       builder:
-          (context) => Padding(
-            padding: const EdgeInsets.symmetric(vertical: 20),
+          (_) => Padding(
+            padding: EdgeInsets.symmetric(vertical: 20.h),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: 20.w,
+                    vertical: 10.h,
+                  ),
                   child: Text(
                     'Network Fees',
                     style: TextStyle(
                       color: AppColors.textPrimary,
-                      fontFamily: 'Inter',
-                      fontSize: 18,
+                      fontSize: 18.sp,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
@@ -379,25 +405,27 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   (fee) => ListTile(
                     title: Text(
                       fee['label']!,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textPrimary,
-                        fontFamily: 'Inter',
-                        fontSize: 16,
+                        fontSize: 16.sp,
                         fontWeight: FontWeight.w500,
                       ),
                     ),
                     subtitle: Text(
                       fee['subtitle']!,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textSecondary,
-                        fontFamily: 'Inter',
-                        fontSize: 14,
+                        fontSize: 14.sp,
                       ),
                     ),
                     trailing:
                         ref.watch(settingsNotifierProvider).networkFee ==
                                 fee['label']
-                            ? const Icon(Icons.check, color: AppColors.primary)
+                            ? Icon(
+                              Icons.check,
+                              color: AppColors.primary,
+                              size: 22.sp,
+                            )
                             : null,
                     onTap: () {
                       ref
@@ -416,17 +444,16 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
 class _SectionHeader extends StatelessWidget {
   final String title;
-
   const _SectionHeader({required this.title});
 
   @override
   Widget build(BuildContext context) {
     return Text(
       title,
-      style: const TextStyle(
+      style: TextStyle(
         color: AppColors.textSecondary,
         fontFamily: 'Inter',
-        fontSize: 12,
+        fontSize: 12.sp,
         fontWeight: FontWeight.w600,
         letterSpacing: 0.5,
       ),
@@ -451,32 +478,31 @@ class _SettingTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(20),
+      borderRadius: BorderRadius.circular(20.r),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 16.h),
         decoration: BoxDecoration(
           color: AppColors.surface,
-          borderRadius: BorderRadius.circular(20),
+          borderRadius: BorderRadius.circular(20.r),
         ),
         child: Row(
           children: [
-            Icon(icon, color: iconColor, size: 24),
-            const SizedBox(width: 16),
+            Icon(icon, color: iconColor, size: 24.sp),
+            SizedBox(width: 16.w),
             Expanded(
               child: Text(
                 title,
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textPrimary,
-                  fontFamily: 'Inter',
-                  fontSize: 16,
+                  fontSize: 16.sp,
                   fontWeight: FontWeight.w400,
                 ),
               ),
             ),
-            const Icon(
+            Icon(
               Icons.chevron_right,
               color: AppColors.textSecondary,
-              size: 24,
+              size: 24.sp,
             ),
           ],
         ),
@@ -504,42 +530,32 @@ class _SettingValueTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(20),
+      borderRadius: BorderRadius.circular(20.r),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 16.h),
         decoration: BoxDecoration(
           color: AppColors.surface,
-          borderRadius: BorderRadius.circular(20),
+          borderRadius: BorderRadius.circular(20.r),
         ),
         child: Row(
           children: [
-            Icon(icon, color: iconColor, size: 24),
-            const SizedBox(width: 16),
+            Icon(icon, color: iconColor, size: 24.sp),
+            SizedBox(width: 16.w),
             Expanded(
               child: Text(
                 title,
-                style: const TextStyle(
-                  color: AppColors.textPrimary,
-                  fontFamily: 'Inter',
-                  fontSize: 16,
-                  fontWeight: FontWeight.w400,
-                ),
+                style: TextStyle(color: AppColors.textPrimary, fontSize: 16.sp),
               ),
             ),
             Text(
               value,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontFamily: 'Inter',
-                fontSize: 14,
-                fontWeight: FontWeight.w400,
-              ),
+              style: TextStyle(color: AppColors.textSecondary, fontSize: 14.sp),
             ),
-            const SizedBox(width: 8),
-            const Icon(
+            SizedBox(width: 8.w),
+            Icon(
               Icons.chevron_right,
               color: AppColors.textSecondary,
-              size: 24,
+              size: 24.sp,
             ),
           ],
         ),
@@ -566,24 +582,19 @@ class _SettingToggleTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 12.h),
       decoration: BoxDecoration(
         color: AppColors.surface,
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: BorderRadius.circular(20.r),
       ),
       child: Row(
         children: [
-          Icon(icon, color: iconColor, size: 24),
-          const SizedBox(width: 16),
+          Icon(icon, color: iconColor, size: 24.sp),
+          SizedBox(width: 16.w),
           Expanded(
             child: Text(
               title,
-              style: const TextStyle(
-                color: AppColors.textPrimary,
-                fontFamily: 'Inter',
-                fontSize: 16,
-                fontWeight: FontWeight.w400,
-              ),
+              style: TextStyle(color: AppColors.textPrimary, fontSize: 16.sp),
             ),
           ),
           Switch(


### PR DESCRIPTION
**Overview**

This pull request updates the entire Profile Screen flow to use responsive sizing powered by ScreenUtil, ensuring consistent rendering across various device sizes and resolutions. Hard-coded pixel values were replaced with dynamic scaling units such as .w, .h, .sp, and .r to improve UI adaptability and maintain visual integrity across multiple devices.

Key Changes

Migrated all static dimensions in the Profile and related  screens to ScreenUtil scaling.

Updated paddings, margins, icon sizes, radii, font sizes, and container dimensions to use responsive units.

Improved layout consistency and text visibility on smaller devices.

Enhanced image display logic for profile photos to ensure proper scaling within circular frames.

Improved tap targets and component spacing for better accessibility.

Ensured no behavioral changes to business logic or state management flow.

Conducted light cleanup and alignment fixes for widgets with inconsistent spacing.

**Why This Change Was Needed**

Hardcoded sizing previously caused layout inconsistencies across devices, leading to overflowing widgets, text truncation, and uneven spacing. Adopting ScreenUtil improves UI predictability and prepares the Profile Screen flow for a wider range of device form factors.

**Testing & Validation**

Verified layout scaling on multiple screen sizes.

Manually tested profile photo selection, display, and removal.

Ensured that performance remains unaffected after scaling changes.

Additional Notes

No API or backend behavior was modified.

Future PRs may extend the same responsive approach to additional flows for global consistency.