### PR TITLE
Fix iOS build: Force local Rust compilation to avoid timeout (#47)

### DIFF
--- a/cargokit_options.yaml
+++ b/cargokit_options.yaml
@@ -1,0 +1,2 @@
+use_precompiled_binaries: false
+verbose_logging: true


### PR DESCRIPTION
https://github.com/auwalrg8/Sabi/issues/47#issue-3750074615
#This commit adds cargokit_options.yaml to disable precompiled binaries and enable verbose logging. This fixes the build timeout failure.